### PR TITLE
Revert "feat(helm): update chart node-feature-discovery ( 0.15.4 → 0.16.0 )"

### DIFF
--- a/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: node-feature-discovery
-      version: 0.16.0
+      version: 0.15.4
       sourceRef:
         kind: HelmRepository
         name: node-feature-discovery


### PR DESCRIPTION
Reverts adampetrovic/home-ops#338

Upgrade once https://github.com/kubernetes-sigs/node-feature-discovery/pull/1728 is merged