### PR TITLE
Revert "feat(container): update image ghcr.io/siderolabs/kubelet ( v1.30.3 → v1.31.0 )"

### DIFF
--- a/.taskfiles/Talos/Taskfile.yaml
+++ b/.taskfiles/Talos/Taskfile.yaml
@@ -8,7 +8,7 @@ vars:
   TALOS_VERSION: v1.7.6
   TALOS_SCHEMATIC_ID: 5169bf5329d9d9c7ae670f206d7c17a62bb38037db61625c8dc4ef5f4e77a0f4
   # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-  KUBERNETES_VERSION: v1.31.0
+  KUBERNETES_VERSION: v1.30.3
   TALOS_SCRIPTS_DIR: "{{.ROOT_DIR}}/.taskfiles/Talos/scripts"
 
 tasks:

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.7.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.31.0
+kubernetesVersion: v1.30.3
 
 clusterName: &cluster home-kubernetes
 endpoint: https://10.0.80.99:6443


### PR DESCRIPTION
Reverts adampetrovic/home-ops#550

Talos 1.7.6 only supports up to Kubernetes v1.30