### PR TITLE
fix(paperless): switch tika image from paperless fork to Apache mainline

### DIFF
--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -41,8 +41,8 @@ spec:
               - {name: DISABLE_GOOGLE_CHROME, value: '1'}
           tika:
             image:
-              repository: ghcr.io/paperless-ngx/tika
-              tag: 2.9.1-full
+              repository: apache/tika
+              tag: latest-full
               pullPolicy: IfNotPresent
           app:
             image:


### PR DESCRIPTION
Paperless-ngx stopped maintaining their tika fork, so switch to the
official Apache Tika image at apache/tika with the latest-full tag.