### PR TITLE
feat(default): switch filebrowser to filebrowser quantum

### DIFF
--- a/kubernetes/apps/default/filebrowser/app/config/config.yaml
+++ b/kubernetes/apps/default/filebrowser/app/config/config.yaml
@@ -1,0 +1,7 @@
+server:
+  database: /data/filebrowser.db
+  cacheDir: /tmp/.cache
+  sources:
+    - path: /mnt
+      config:
+        defaultEnabled: true

--- a/kubernetes/apps/default/filebrowser/app/helmrelease.yaml
+++ b/kubernetes/apps/default/filebrowser/app/helmrelease.yaml
@@ -97,21 +97,13 @@ spec:
         tls:
           - hosts:
               - *publicHost
-    configMaps:
-      config:
-        data:
-          config.yaml: |-
-            server:
-              database: /data/filebrowser.db
-              cacheDir: /tmp/.cache
-              sources:
-                - path: /mnt
-                  config:
-                    defaultEnabled: true
     persistence:
       config:
         type: configMap
-        identifier: config
+        name: filebrowser-configmap
+        globalMounts:
+          - path: /config/config.yaml
+            subPath: config.yaml
       data:
         existingClaim: *app
         globalMounts:

--- a/kubernetes/apps/default/filebrowser/app/kustomization.yaml
+++ b/kubernetes/apps/default/filebrowser/app/kustomization.yaml
@@ -4,3 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+configMapGenerator:
+  - name: filebrowser-configmap
+    files:
+      - ./config/config.yaml
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
Replace the original filebrowser (docker.io/filebrowser/filebrowser) with
FileBrowser Quantum (ghcr.io/gtsteffaniak/filebrowser) which provides
improved search, real-time UI updates, and modern file management features.

Key changes:
- Image: ghcr.io/gtsteffaniak/filebrowser v1.1.1-stable
- Config: YAML-based configuration via configMap instead of env vars
- Port: 80 (quantum default) instead of 7000
- Health probe: / instead of /health
- Database PVC remounted at /data, config.yaml via configMap at /config
- Added /tmp emptyDir for cache

https://claude.ai/code/session_01Q76SWaBL3JuRFHYRT7wmwR