### PR TITLE
fix(container): update frigate from beta to stable release (0.16.0-beta4 → 0.16.4)

### DIFF
--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/blakeblackshear/frigate
-              tag: 0.16.0-beta4@sha256:0f39e8111ea7ad986d70b43bf572fe64a923c1e80fbdb3580f489c8db6edefd8
+              tag: 0.16.4@sha256:1f8dbaaa4c7c2855c2aef711842d13b0c20bfdc3f28ad88faf66aa1bc219b108
             env:
               TZ: "Australia/Sydney"
             envFrom:


### PR DESCRIPTION
The beta tag prevented Renovate from detecting updates due to
ignoreUnstable defaulting to true for Docker images. Moving to a
stable tag allows Renovate to track future releases normally.

https://claude.ai/code/session_01EBH7wCqT3yTicnBtzqDuju