### PR TITLE
feat(network): Phase 0 — Deploy Envoy Gateway alongside nginx

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -1,0 +1,173 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/envoyproxy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: envoy
+spec:
+  logging:
+    level:
+      default: info
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 2
+        container:
+          resources:
+            requests:
+              cpu: 100m
+            limits:
+              memory: 2Gi
+      envoyService:
+        externalTrafficPolicy: Local
+  shutdown:
+    drainTimeout: 180s
+  telemetry:
+    metrics:
+      prometheus:
+        compression:
+          type: Zstd
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/gatewayclass_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: envoy
+    namespace: network
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/gateway_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: envoy-internal
+spec:
+  gatewayClassName: envoy
+  infrastructure:
+    annotations:
+      io.cilium/lb-ipam-ips: "10.0.80.202"
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      protocol: HTTPS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: "${SECRET_DOMAIN/./-}-production-tls"
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/gateway_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: envoy-external
+  annotations:
+    external-dns.alpha.kubernetes.io/target: &hostname "external.${SECRET_PUBLIC_DOMAIN}"
+spec:
+  gatewayClassName: envoy
+  infrastructure:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: *hostname
+      io.cilium/lb-ipam-ips: "10.0.80.203"
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      protocol: HTTPS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: "${SECRET_DOMAIN/./-}-production-tls"
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/backendtrafficpolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: envoy
+spec:
+  compressor:
+    - type: Zstd
+      zstd: {}
+    - type: Brotli
+      brotli: {}
+    - type: Gzip
+      gzip: {}
+  retry:
+    numRetries: 2
+    retryOn:
+      triggers:
+        - reset
+  targetSelectors:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+  tcpKeepalive: {}
+  timeout:
+    http:
+      requestTimeout: 0s
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/clienttrafficpolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: envoy
+spec:
+  clientIPDetection:
+    xForwardedFor:
+      trustedCIDRs:
+        - 10.69.0.0/16
+  http2:
+    onInvalidMessage: TerminateStream
+  http3: {}
+  targetSelectors:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+  tcpKeepalive: {}
+  tls:
+    minVersion: "1.2"
+    alpnProtocols:
+      - h2
+      - http/1.1
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-redirect
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: none
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+      sectionName: http
+    - name: envoy-internal
+      namespace: network
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: envoy-gateway
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: envoy-gateway
+  interval: 1h
+  values:
+    config:
+      envoyGateway:
+        provider:
+          type: Kubernetes
+          kubernetes:
+            deploy:
+              type: GatewayNamespace

--- a/kubernetes/apps/network/envoy-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./envoy.yaml
+  - ./helmrelease.yaml
+  - ./observability.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/network/envoy-gateway/app/observability.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/observability.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-proxy
+spec:
+  jobLabel: envoy-proxy
+  namespaceSelector:
+    matchNames:
+      - network
+  podMetricsEndpoints:
+    - port: metrics
+      path: /stats/prometheus
+      honorLabels: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: proxy
+      app.kubernetes.io/name: envoy
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: envoy-gateway
+spec:
+  endpoints:
+    - port: metrics
+      path: /metrics
+      honorLabels: true
+  jobLabel: envoy-gateway
+  namespaceSelector:
+    matchNames:
+      - network
+  selector:
+    matchLabels:
+      control-plane: envoy-gateway

--- a/kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: envoy-gateway
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.7.0
+  url: oci://docker.io/envoyproxy/gateway-helm

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: envoy-gateway
+  namespace: network
+spec:
+  dependsOn:
+    - name: ingress-nginx-certificates
+  interval: 1h
+  path: ./kubernetes/apps/network/envoy-gateway/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: false

--- a/kubernetes/apps/network/external-dns/external/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/external/helmrelease.yaml
@@ -43,11 +43,12 @@ spec:
     extraArgs:
       - --ingress-class=external
       - --cloudflare-proxied
+      - --gateway-name=envoy-external
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint
     logLevel: debug
     policy: sync
-    sources: ["crd", "ingress"]
+    sources: ["crd", "ingress", "gateway-httproute"]
     txtPrefix: k8s.
     txtOwnerId: kubernetes-home-external
     domainFilters:

--- a/kubernetes/apps/network/external-dns/internal/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/internal/helmrelease.yaml
@@ -42,10 +42,11 @@ spec:
             key: api-token
     extraArgs:
       - --ingress-class=internal
+      - --gateway-name=envoy-internal
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint
     policy: sync
-    sources: ["crd", "ingress", "service"]
+    sources: ["crd", "ingress", "gateway-httproute", "service"]
     txtPrefix: k8s.
     txtOwnerId: kubernetes-home-internal
     domainFilters:

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./adguard/ks.yaml
   - ./cloudflared/ks.yaml
   - ./echo-server/ks.yaml
+  - ./envoy-gateway/ks.yaml
   - ./external-dns/ks.yaml
   - ./ingress-nginx/ks.yaml
   - ./multus/ks.yaml


### PR DESCRIPTION
## Phase 0: Foundation

Part of #1960

Deploys Envoy Gateway alongside the existing nginx ingress controllers. **No existing traffic is affected** — Envoy Gateway gets its own IPs and runs in parallel.

### Changes

**New: `kubernetes/apps/network/envoy-gateway/`**
- `ocirepository.yaml` — OCI source for `envoy-gateway` chart v1.7.0
- `helmrelease.yaml` — Envoy Gateway controller with `GatewayNamespace` deploy mode
- `envoy.yaml` — Full gateway stack:
  - `EnvoyProxy` — 2 replicas, resource limits, Zstd metrics compression, 180s drain timeout
  - `GatewayClass` — `envoy` class backed by Envoy Gateway controller
  - `Gateway envoy-internal` — IP `10.0.80.202`, HTTPS listener with wildcard cert
  - `Gateway envoy-external` — IP `10.0.80.203`, HTTPS listener with wildcard cert, external-dns target annotation
  - `BackendTrafficPolicy` — Zstd/Brotli/Gzip compression, retries, keepalive, unlimited request timeout
  - `ClientTrafficPolicy` — XFF trusted CIDRs (`10.69.0.0/16`), HTTP/2, HTTP/3, TLS 1.2+
  - `HTTPRoute https-redirect` — HTTP→HTTPS 301 redirect for both gateways
- `observability.yaml` — PodMonitor for envoy proxies + ServiceMonitor for the controller
- `ks.yaml` — Flux Kustomization, depends on `ingress-nginx-certificates` (reuses existing wildcard cert)

**Modified: `kubernetes/apps/network/kustomization.yaml`**
- Added `./envoy-gateway/ks.yaml` to resources

**Modified: `kubernetes/apps/network/external-dns/internal/helmrelease.yaml`**
- Added `--gateway-name=envoy-internal` to `extraArgs`
- Added `gateway-httproute` to `sources` (alongside existing `ingress`)

**Modified: `kubernetes/apps/network/external-dns/external/helmrelease.yaml`**
- Added `--gateway-name=envoy-external` to `extraArgs`
- Added `gateway-httproute` to `sources` (alongside existing `ingress`)

### What this enables

After this merges, the cluster will have both nginx and Envoy Gateway running. Apps can be gradually migrated from `ingress` blocks to `route` blocks in subsequent PRs (Phases 1-7).

### Modeled off

- [onedr0p/home-ops envoy-gateway](https://github.com/onedr0p/home-ops/tree/main/kubernetes/apps/network/envoy-gateway)
