### PR TITLE
feat(network): Phase 1 — Smoke test with tautulli

### DIFF
--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -53,21 +53,13 @@ spec:
         ports:
           http:
             port: *port
-    ingress:
+    route:
       main:
-        enabled: true
-        className: internal
-        hosts:
-          - host: &host tautulli.${SECRET_DOMAIN}
-            paths:
-              - path: /
-                pathType: Prefix
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
+        hostnames:
+          - tautulli.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
     persistence:
       config:
         enabled: true


### PR DESCRIPTION
Part of #1960

Migrates tautulli from nginx `ingress` to Envoy Gateway `route` as a smoke test.

### Changes

- `kubernetes/apps/media/tautulli/app/helmrelease.yaml` — replaced `ingress` block with `route` block pointing at `envoy-internal` gateway

### Before
```yaml
ingress:
  main:
    enabled: true
    className: internal
    hosts:
      - host: tautulli.${SECRET_DOMAIN}
        paths:
          - path: /
            pathType: Prefix
            service:
              identifier: app
              port: http
    tls:
      - hosts:
          - *host
```

### After
```yaml
route:
  main:
    hostnames:
      - tautulli.${SECRET_DOMAIN}
    parentRefs:
      - name: envoy-internal
        namespace: network
```

### Validation
- [x] DNS resolves to envoy-internal IP (10.0.80.202)
- [x] HTTPS works with wildcard cert
- [x] Tautulli UI loads correctly
- [x] external-dns logs show the HTTPRoute was picked up
