### PR TITLE
feat(network): Phase 4 — Migrate authelia-protected apps with SecurityPolicy

### DIFF
--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -85,27 +85,13 @@ spec:
         ports:
           http:
             port: *port
-    ingress:
+    route:
       app:
-        enabled: true
-        className: internal
-        annotations:
-          nginx.ingress.kubernetes.io/auth-method: GET
-          nginx.ingress.kubernetes.io/auth-url: http://authelia.security.svc.cluster.local/api/verify
-          nginx.ingress.kubernetes.io/auth-signin: https://auth.${SECRET_DOMAIN}?rm=$request_method
-          nginx.ingress.kubernetes.io/auth-response-headers: Remote-User,Remote-Name,Remote-Groups,Remote-Email
-          nginx.ingress.kubernetes.io/auth-snippet: proxy_set_header X-Forwarded-Method $request_method;
-        hosts:
-          - host: &host paperless.${SECRET_DOMAIN}
-            paths:
-              - path: /
-                pathType: Prefix
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
+        hostnames:
+          - paperless.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
     persistence:
       config:
         enabled: true

--- a/kubernetes/apps/default/paperless-ngx/app/kustomization.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+components:
+  - ../../../../components/authelia-proxy

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -92,27 +92,13 @@ spec:
             port: *port-bt
             protocol: TCP
             targetPort: *port-bt
-    ingress:
+    route:
       main:
-        enabled: true
-        className: internal
-        annotations:
-          nginx.ingress.kubernetes.io/auth-method: GET
-          nginx.ingress.kubernetes.io/auth-url: http://authelia.security.svc.cluster.local/api/verify
-          nginx.ingress.kubernetes.io/auth-signin: https://auth.${SECRET_DOMAIN}?rm=$request_method
-          nginx.ingress.kubernetes.io/auth-response-headers: Remote-User,Remote-Name,Remote-Groups,Remote-Email
-          nginx.ingress.kubernetes.io/auth-snippet: proxy_set_header X-Forwarded-Method $request_method;
-        hosts:
-          - host: &host qb.${SECRET_DOMAIN}
-            paths:
-              - path: /
-                pathType: Prefix
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
+        hostnames:
+          - qb.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
     persistence:
       config:
         enabled: true

--- a/kubernetes/apps/media/qbittorrent/app/kustomization.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./helmrelease.yaml
+  - ./helmrelease.yamlcomponents:
+  - ../../../../components/authelia-proxy

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -81,31 +81,13 @@ spec:
         ports:
           http:
             port: *port
-    ingress:
+    route:
       main:
-        enabled: true
-        className: internal
-        annotations:
-          nginx.ingress.kubernetes.io/auth-method: GET
-          nginx.ingress.kubernetes.io/auth-url: http://authelia.security.svc.cluster.local/api/verify
-          nginx.ingress.kubernetes.io/auth-signin: https://auth.${SECRET_DOMAIN}?rm=$request_method
-          nginx.ingress.kubernetes.io/auth-response-headers: Remote-User,Remote-Name,Remote-Groups,Remote-Email
-          nginx.ingress.kubernetes.io/auth-snippet: proxy_set_header X-Forwarded-Method $request_method;
-          nginx.ingress.kubernetes.io/configuration-snippet: |
-            proxy_set_header Accept-Encoding "";
-            sub_filter '</head>' '<link rel="stylesheet" type="text/css" href="https://theme-park.devbu.io/css/base/radarr/nord.css"></head>';
-            sub_filter_once on;
-        hosts:
-          - host: &host radarr.${SECRET_DOMAIN}
-            paths:
-              - path: /
-                pathType: Prefix
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
+        hostnames:
+          - radarr.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
     persistence:
       config:
         enabled: true

--- a/kubernetes/apps/media/radarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/radarr/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
-  - ./helmrelease.yaml
+  - ./helmrelease.yamlcomponents:
+  - ../../../../components/authelia-proxy

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -70,28 +70,13 @@ spec:
           http:
             port: *port
 
-    ingress:
+    route:
       main:
-        enabled: true
-        className: internal
-        annotations:
-          nginx.ingress.kubernetes.io/auth-method: GET
-          nginx.ingress.kubernetes.io/auth-url: http://authelia.security.svc.cluster.local/api/verify
-          nginx.ingress.kubernetes.io/auth-signin: https://auth.${SECRET_DOMAIN}?rm=$request_method
-          nginx.ingress.kubernetes.io/auth-response-headers: Remote-User,Remote-Name,Remote-Groups,Remote-Email
-          nginx.ingress.kubernetes.io/auth-snippet: proxy_set_header X-Forwarded-Method $request_method;
-        hosts:
-          - host: &host shelfmark.${SECRET_DOMAIN}
-            paths:
-              - path: /
-                pathType: Prefix
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
-
+        hostnames:
+          - shelfmark.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
     persistence:
       config:
         enabled: true

--- a/kubernetes/apps/media/shelfmark/app/kustomization.yaml
+++ b/kubernetes/apps/media/shelfmark/app/kustomization.yaml
@@ -4,3 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+components:
+  - ../../../../components/authelia-proxy

--- a/kubernetes/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo-server/app/helmrelease.yaml
@@ -80,38 +80,16 @@ spec:
             path: /metrics
             interval: 1m
             scrapeTimeout: 10s
-    ingress:
+    route:
       main:
-        enabled: true
-        className: external
-        annotations:
-          external-dns.alpha.kubernetes.io/target: "external.${SECRET_PUBLIC_DOMAIN}"
-        hosts:
-          - host: &host "{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"
-            paths:
-              - path: /
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
       internal:
-        enabled: true
-        className: internal
-        annotations:
-          nginx.ingress.kubernetes.io/auth-method: GET
-          nginx.ingress.kubernetes.io/auth-url: http://authelia.security.svc.cluster.local/api/verify
-          nginx.ingress.kubernetes.io/auth-signin: https://auth.${SECRET_DOMAIN}?rm=$request_method
-          nginx.ingress.kubernetes.io/auth-response-headers: Remote-User,Remote-Name,Remote-Groups,Remote-Email
-          nginx.ingress.kubernetes.io/auth-snippet: proxy_set_header X-Forwarded-Method $request_method;
-        hosts:
-          - host: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
-            paths:
-              - path: /
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network

--- a/kubernetes/apps/network/echo-server/app/kustomization.yaml
+++ b/kubernetes/apps/network/echo-server/app/kustomization.yaml
@@ -3,3 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+components:
+  - ../../../../components/authelia-proxy

--- a/kubernetes/apps/security/authelia/app/kustomization.yaml
+++ b/kubernetes/apps/security/authelia/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./referencegrant.yaml
 configMapGenerator:
   - name: authelia-configmap
     files:

--- a/kubernetes/apps/security/authelia/app/referencegrant.yaml
+++ b/kubernetes/apps/security/authelia/app/referencegrant.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: authelia-ext-auth
+spec:
+  from:
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: default
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: media
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: network
+  to:
+    - group: ""
+      kind: Service
+      name: authelia

--- a/kubernetes/components/authelia-proxy/kustomization.yaml
+++ b/kubernetes/components/authelia-proxy/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./securitypolicy.yaml

--- a/kubernetes/components/authelia-proxy/securitypolicy.yaml
+++ b/kubernetes/components/authelia-proxy/securitypolicy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: ${APP}
+spec:
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - X-Forwarded-Proto
+      - cookie
+    http:
+      backendRefs:
+        - name: authelia
+          namespace: security
+          port: 80
+      path: /api/verify
+      headersToBackend:
+        - Remote-User
+        - Remote-Name
+        - Remote-Groups
+        - Remote-Email
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: ${APP}


### PR DESCRIPTION
Part of #1960

Migrates the 5 apps that used nginx forward-auth annotations to Envoy Gateway with native `SecurityPolicy` ext-auth.

### New: Reusable authelia-proxy Kustomize component

`kubernetes/components/authelia-proxy/` — a Kustomize component that creates an Envoy Gateway `SecurityPolicy` with `extAuth` targeting authelia. Any app can include it via:

```yaml
components:
  - ../../../../components/authelia-proxy
```

The `SecurityPolicy` targets the HTTPRoute named `${APP}` (substituted by Flux).

### New: ReferenceGrant for cross-namespace auth

`kubernetes/apps/security/authelia/app/referencegrant.yaml` — allows SecurityPolicy resources in `default`, `media`, and `network` namespaces to reference the authelia Service in the `security` namespace.

### Apps migrated
- **paperless-ngx** — was `two_factor` policy via forward-auth
- **qbittorrent** — was `one_factor` + API bypass (bypass stays in authelia config)
- **radarr** — was `one_factor` + API bypass + theme-park CSS (CSS dropped)
- **shelfmark** — was `one_factor`
- **echo-server** — was `one_factor` on internal ingress (external route has no auth)

### Net change
`-120 lines, +98 lines`
