### PR TITLE
feat(network): Phase 5 — Migrate non-app-template apps to HTTPRoute

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -455,13 +455,7 @@ spec:
     serviceMonitor:
       enabled: true
     ingress:
-      enabled: true
-      ingressClassName: internal
-      hosts:
-        - &host grafana.${SECRET_DOMAIN}
-      tls:
-        - hosts:
-            - *host
+      enabled: false
     persistence:
       enabled: false
     testFramework:

--- a/kubernetes/apps/observability/grafana/app/httproute.yaml
+++ b/kubernetes/apps/observability/grafana/app/httproute.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - grafana.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: grafana
+          port: 80

--- a/kubernetes/apps/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -44,14 +44,7 @@ spec:
     cleanPrometheusOperatorObjectNames: true
     alertmanager:
       ingress:
-        enabled: true
-        pathType: Prefix
-        ingressClassName: internal
-        hosts:
-          - &host alertmanager.${SECRET_DOMAIN}
-        tls:
-          - hosts:
-              - *host
+        enabled: false
       alertmanagerSpec:
         useExistingSecret: true
         configSecret: alertmanager-secret
@@ -73,14 +66,7 @@ spec:
       enabled: false
     prometheus:
       ingress:
-        enabled: true
-        ingressClassName: internal
-        pathType: Prefix
-        hosts:
-          - &host prometheus.${SECRET_DOMAIN}
-        tls:
-          - hosts:
-              - *host
+        enabled: false
       prometheusSpec:
         image:
           registry: quay.io

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: alertmanager
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - alertmanager.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: alertmanager-operated
+          port: 9093
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prometheus
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - prometheus.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: prometheus-operated
+          port: 9090

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./prometheusrules
   - ./scrapeconfig.yaml
 configMapGenerator:

--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -91,16 +91,7 @@ spec:
     gateway:
       enabled: true
       ingress:
-        enabled: true
-        ingressClassName: internal
-        hosts:
-          - host: &host loki.${SECRET_DOMAIN}
-            paths:
-              - path: /
-                pathType: Prefix
-        tls:
-          - hosts:
-              - *host
+        enabled: false
     # Disable other components for SingleBinary mode
     read:
       replicas: 0

--- a/kubernetes/apps/observability/loki/app/httproute.yaml
+++ b/kubernetes/apps/observability/loki/app/httproute.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: loki
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - loki.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: loki-gateway
+          port: 80

--- a/kubernetes/apps/observability/loki/app/kustomization.yaml
+++ b/kubernetes/apps/observability/loki/app/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -45,13 +45,7 @@ spec:
           disabled: true
     ingress:
       dashboard:
-        ingressClassName: internal
-        host:
-          name: &host rook.${SECRET_DOMAIN}
-          path: /
-        tls:
-          - hosts:
-              - *host
+        ingressClassName: ""
     toolbox:
       enabled: true
 
@@ -255,11 +249,4 @@ spec:
           parameters:
             region: us-east-1
         ingress:
-          enabled: true
-          ingressClassName: internal
-          host:
-            name: &host rgw.${SECRET_DOMAIN}
-            path: /
-          tls:
-            - hosts:
-                - *host
+          enabled: false

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/httproute.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/httproute.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rook-ceph-dashboard
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - rook.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: rook-ceph-mgr-dashboard
+          port: 7000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rook-ceph-rgw
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - rgw.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: rook-ceph-rgw-ceph-objectstore
+          port: 80

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml


### PR DESCRIPTION
Part of #1960

Migrates apps that use upstream Helm charts (not app-template) by disabling their built-in ingress and creating companion `HTTPRoute` manifests.

### Apps migrated
- **grafana** → `httproute.yaml` → `grafana:80`
- **alertmanager** → `httproute.yaml` → `alertmanager-operated:9093`
- **prometheus** → `httproute.yaml` → `prometheus-operated:9090`
- **loki** → `httproute.yaml` → `loki-gateway:80`
- **rook-ceph dashboard** → `httproute.yaml` → `rook-ceph-mgr-dashboard:7000`
- **rook-ceph rgw** → `httproute.yaml` → `rook-ceph-rgw-ceph-objectstore:80`

### Pattern
Each chart's ingress is set to `enabled: false`, and a standalone `HTTPRoute` resource is added to the app's kustomization. This decouples routing from the Helm release lifecycle.

### Net change
`-48 lines (helm values), +100 lines (HTTPRoutes + kustomization refs)`
