### PR TITLE
feat(network): Phase 6 — Migrate proxy entries (NAS, NVR, UniFi)

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -17,3 +17,21 @@ spec:
     namespace: flux-system
   targetNamespace: network
   wait: false
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: envoy-gateway-proxy
+  namespace: network
+spec:
+  dependsOn:
+    - name: envoy-gateway
+  interval: 1h
+  path: ./kubernetes/apps/network/envoy-gateway/proxy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/network/envoy-gateway/proxy/backend-tls.yaml
+++ b/kubernetes/apps/network/envoy-gateway/proxy/backend-tls.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTLSPolicy
+metadata:
+  name: external-nas
+  namespace: default
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: external-nas
+  validation:
+    wellKnownCACertificates: System
+    hostname: nas-direct.${SECRET_DOMAIN}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTLSPolicy
+metadata:
+  name: external-nvr
+  namespace: default
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: external-nvr
+  validation:
+    wellKnownCACertificates: System
+    hostname: nvr-direct.${SECRET_DOMAIN}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTLSPolicy
+metadata:
+  name: external-unifi
+  namespace: default
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: external-unifi
+  validation:
+    wellKnownCACertificates: System
+    hostname: unifi.${SECRET_DOMAIN}

--- a/kubernetes/apps/network/envoy-gateway/proxy/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/proxy/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./backend-tls.yaml
+  - ./nas.yaml
+  - ./nvr.yaml
+  - ./unifi.yaml

--- a/kubernetes/apps/network/envoy-gateway/proxy/nas.yaml
+++ b/kubernetes/apps/network/envoy-gateway/proxy/nas.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-nas
+  namespace: default
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - nas.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: external-nas
+          port: 5001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-nas
+  namespace: default
+spec:
+  ports:
+    - name: external-nas
+      port: 5001
+  type: ExternalName
+  externalName: nas-direct.${SECRET_DOMAIN}

--- a/kubernetes/apps/network/envoy-gateway/proxy/nvr.yaml
+++ b/kubernetes/apps/network/envoy-gateway/proxy/nvr.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-nvr
+  namespace: default
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - nvr.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: external-nvr
+          port: 5001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-nvr
+  namespace: default
+spec:
+  ports:
+    - name: external-nvr
+      port: 5001
+  type: ExternalName
+  externalName: nvr-direct.${SECRET_DOMAIN}

--- a/kubernetes/apps/network/envoy-gateway/proxy/unifi.yaml
+++ b/kubernetes/apps/network/envoy-gateway/proxy/unifi.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-unifi
+  namespace: default
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - unifi.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: external-unifi
+          port: 443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-unifi
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 443
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: external-unifi
+  namespace: default
+subsets:
+  - addresses:
+      - ip: 10.0.0.1
+    ports:
+      - port: 443


### PR DESCRIPTION
Part of #1960

Migrates the 3 external device proxy entries (NAS, NVR, UniFi) from nginx `Ingress` to `HTTPRoute`, keeping the existing `Service`/`Endpoints` resources. These are placed under `envoy-gateway/proxy/` with their own Flux kustomization.

### Changes
- **`envoy-gateway/proxy/nas.yaml`** — HTTPRoute + ExternalName Service for Synology NAS
- **`envoy-gateway/proxy/nvr.yaml`** — HTTPRoute + ExternalName Service for NVR
- **`envoy-gateway/proxy/unifi.yaml`** — HTTPRoute + Service/Endpoints for UniFi (10.0.0.1)
- **`envoy-gateway/proxy/backend-tls.yaml`** — `BackendTLSPolicy` for all 3 backends (HTTPS with system CA validation)
- **`envoy-gateway/ks.yaml`** — added `envoy-gateway-proxy` Flux Kustomization depending on `envoy-gateway`

### Notes
The original nginx proxy entries used `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` and `proxy-ssl-verify: "off"`. The Envoy equivalent uses `BackendTLSPolicy` with `wellKnownCACertificates: System`. If the devices use self-signed certs not in the system trust store, these may need to be changed to use a custom CA bundle or skipped.
