### PR TITLE
fix(bootstrap): add envoy-gateway helm chart CRDs to bootstrap process

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,5 @@
 [env]
 SOPS_AGE_KEY_FILE = "~/.config/sops/age/keys.txt"
+
+[tools]
+helm = "latest"


### PR DESCRIPTION
## Summary

Add Envoy Gateway Helm chart CRD extraction to the bootstrap process so Gateway API and Envoy Gateway CRDs are available before Flux reconciles.

### Problem

The envoy-gateway Flux Kustomization was failing with:
```
GatewayClass/network/envoy dry-run failed: no matches for kind "GatewayClass" in version "gateway.networking.k8s.io/v1"
```

The Gateway API CRDs (already in `apply_crds`) were never applied to the running cluster, and the Envoy Gateway-specific CRDs (`EnvoyProxy`, `BackendTrafficPolicy`, `ClientTrafficPolicy`, `SecurityPolicy`, etc.) were missing entirely.

### Changes

- **`scripts/bootstrap-cluster.sh`**: Add helm chart CRD extraction loop to `apply_crds()` that pulls `oci://docker.io/envoyproxy/gateway-helm` v1.7.0 and recursively applies its CRDs. Add `helm` to the CLI check. Pattern follows [onedr0p/home-ops](https://github.com/onedr0p/home-ops/blob/main/bootstrap/helmfile.d/00-crds.yaml).
- **`.mise.toml`**: Add `helm` tool for local development.

### Related

Ref #1960