### PR TITLE
fix(automation): add explicit backendRefs for home-assistant routes

### DIFF
--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -133,12 +133,20 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
       external:
         hostnames:
           - "hass.${SECRET_PUBLIC_DOMAIN}"
         parentRefs:
           - name: envoy-external
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
       codeserver:
         hostnames:
           - "hass-code.${SECRET_DOMAIN}"


### PR DESCRIPTION
The home-assistant app has two services (`app` and `codeserver`), so app-template can't auto-detect which service to use for the `app` and `external` routes. Add explicit `backendRefs` to fix the Helm upgrade error:

```
An explicit rule is required because automatic Service detection is not possible. (route: app)
```

Ref #1960