### PR TITLE
fix(media): fix broken kustomization YAML for qbittorrent and radarr

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/kustomization.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./helmrelease.yamlcomponents:
+  - ./helmrelease.yaml
+components:
   - ../../../../components/authelia-proxy

--- a/kubernetes/apps/media/radarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/radarr/app/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
-  - ./helmrelease.yamlcomponents:
+  - ./helmrelease.yaml
+components:
   - ../../../../components/authelia-proxy


### PR DESCRIPTION
Missing newline between `resources` and `components` in kustomization.yaml for qbittorrent and radarr — caused by a bad merge in Phase 4.

```
# before (broken)
  - ./helmrelease.yamlcomponents:

# after (fixed)
  - ./helmrelease.yaml
components:
```

Ref #1960