### PR TITLE
fix(security): use ext-authz endpoint for authelia SecurityPolicy

### DIFF
--- a/kubernetes/components/authelia-proxy/securitypolicy.yaml
+++ b/kubernetes/components/authelia-proxy/securitypolicy.yaml
@@ -7,14 +7,18 @@ spec:
   extAuth:
     failOpen: false
     headersToExtAuth:
+      - X-Forwarded-Method
       - X-Forwarded-Proto
+      - X-Forwarded-Host
+      - X-Forwarded-Uri
+      - X-Forwarded-For
       - cookie
     http:
       backendRefs:
         - name: authelia
           namespace: security
           port: 80
-      path: /api/verify
+      path: /api/authz/forward-auth
       headersToBackend:
         - Remote-User
         - Remote-Name


### PR DESCRIPTION
Per [Authelia's Envoy Gateway integration docs](https://www.authelia.com/integration/kubernetes/envoy/gateway/), the SecurityPolicy should use `/api/authz/ext-authz/` (the ExtAuthz implementation designed for Envoy) instead of `/api/authz/forward-auth`.

The `forward-auth` endpoint is designed for nginx/traefik-style proxies. The `ext-authz` endpoint is designed for Envoy's native ext_authz filter and handles redirect responses properly.

Also updates `headersToExtAuth` to match Authelia's documented configuration: `accept`, `cookie`, `location`, `authorization`, `proxy-authorization`, `x-forwarded-proto`.

Ref #1960