### PR TITLE
fix(security): use ext-authz endpoint for authelia SecurityPolicy

### DIFF
--- a/kubernetes/components/authelia-proxy/securitypolicy.yaml
+++ b/kubernetes/components/authelia-proxy/securitypolicy.yaml
@@ -5,20 +5,20 @@ metadata:
   name: ${APP}
 spec:
   extAuth:
-    failOpen: false
     headersToExtAuth:
-      - X-Forwarded-Method
-      - X-Forwarded-Proto
-      - X-Forwarded-Host
-      - X-Forwarded-Uri
-      - X-Forwarded-For
+      - accept
       - cookie
+      - location
+      - authorization
+      - proxy-authorization
+      - x-forwarded-proto
+    failOpen: false
     http:
       backendRefs:
         - name: authelia
           namespace: security
           port: 80
-      path: /api/authz/forward-auth
+      path: /api/authz/ext-authz/
       headersToBackend:
         - Remote-User
         - Remote-Name


### PR DESCRIPTION
Per [Authelia's Envoy Gateway integration docs](https://www.authelia.com/integration/kubernetes/envoy/gateway/), use `/api/authz/ext-authz/` (the ExtAuthz implementation designed for Envoy) instead of `/api/authz/forward-auth`.

The `forward-auth` endpoint returns a 302 redirect but Envoy's ext_authz filter strips the Location header. The `ext-authz` endpoint is designed for Envoy's native ext_authz filter and handles redirect responses properly.

Also updates `headersToExtAuth` to match Authelia's documented set: `accept`, `cookie`, `location`, `authorization`, `proxy-authorization`, `x-forwarded-proto`.

Ref #1960