### PR TITLE
fix(network): pin envoy proxy to v1.36 to fix ext-authz Location header stripping

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -14,6 +14,9 @@ spec:
       envoyDeployment:
         replicas: 2
         container:
+          # Pin to v1.36 until https://github.com/envoyproxy/gateway/issues/8202 is fixed
+          # v1.37 strips Location header on ext_authz denial, breaking auth redirects
+          image: docker.io/envoyproxy/envoy:distroless-v1.36.4
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Envoy v1.37 (bundled with Envoy Gateway v1.7.0) [changed ext_authz behaviour](https://github.com/envoyproxy/gateway/issues/8202) — it now requires explicit `allowed_client_headers` configuration to forward headers (like `Location`) on denied responses. The Envoy Gateway SecurityPolicy API doesn't expose this field, so auth redirects are broken.

Pin the envoy proxy image to `distroless-v1.36.4` which has the old permissive behaviour until the upstream fix lands.

Ref #1960