### PR TITLE
fix(media): add explicit backendRefs for qbittorrent route

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -99,6 +99,10 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
     persistence:
       config:
         enabled: true


### PR DESCRIPTION
qbittorrent has a multi-port service (http + bittorrent). Without explicit `backendRefs`, app-template auto-detected port 50413 (BitTorrent) instead of port 80 (web UI), causing 502 upstream connection errors.

Ref #1960