### PR TITLE
fix(automation,network): add explicit backendRefs for multi-service apps

### DIFF
--- a/kubernetes/apps/automation/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/esphome/app/helmrelease.yaml
@@ -98,6 +98,10 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
       codeserver:
         hostnames:
           - "esphome-code.${SECRET_DOMAIN}"

--- a/kubernetes/apps/automation/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/go2rtc/app/helmrelease.yaml
@@ -101,6 +101,10 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
     persistence:
       config-file:
         type: configMap

--- a/kubernetes/apps/network/adguard/app/helmrelease.yaml
+++ b/kubernetes/apps/network/adguard/app/helmrelease.yaml
@@ -75,6 +75,10 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
     persistence:
       config:
         enabled: true

--- a/kubernetes/apps/network/echo-server/ks.yaml
+++ b/kubernetes/apps/network/echo-server/ks.yaml
@@ -19,3 +19,6 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app


### PR DESCRIPTION
Fix 3 broken HelmReleases and 1 missing SecurityPolicy caused by multi-service apps where app-template can't auto-detect which service to route to.

**backendRefs fixes:**
- **esphome** — has `app` + `codeserver` services (same pattern as home-assistant)
- **go2rtc** — has `app` + `streams` (LoadBalancer) services
- **adguard-home** — has `app` + `dns` (LoadBalancer) services

**echo-server SecurityPolicy fix:**
- Added `postBuild.substitute.APP` to `ks.yaml` so the authelia-proxy component's `${APP}` variable gets substituted

Ref #1960