### PR TITLE
fix(network): enable websocket support for unifi proxy

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/proxy/unifi.yaml
+++ b/kubernetes/apps/network/envoy-gateway/proxy/unifi.yaml
@@ -23,6 +23,8 @@ metadata:
   name: external-unifi
   namespace: default
 spec:
+  appProtocols:
+    - gateway.envoyproxy.io/ws
   endpoints:
     - ip:
         address: 10.0.0.1


### PR DESCRIPTION
UniFi controller uses WebSocket connections (`/api/ws/system`, `/api/ws/webrtc/local`) for real-time updates after login. Without WebSocket support, these requests return 400 and the UI stays on a loading screen.

Add `appProtocols: [gateway.envoyproxy.io/ws]` to the UniFi Backend to enable WebSocket upgrade support.

Ref #1960