### PR TITLE
fix(network): force HTTP/1.1 upstream for unifi websocket support

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/proxy/unifi.yaml
+++ b/kubernetes/apps/network/envoy-gateway/proxy/unifi.yaml
@@ -31,3 +31,15 @@ spec:
         port: 443
   tls:
     insecureSkipVerify: true
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: external-unifi
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: external-unifi
+  useClientProtocol: true


### PR DESCRIPTION
The `wss` appProtocol enables WebSocket upgrade on the route, but envoy still negotiates H2 with the UniFi backend over TLS via ALPN. WebSocket upgrades only work over HTTP/1.1, so the UniFi controller rejects them with 400.

Add a `BackendTrafficPolicy` with `useClientProtocol: true` to make envoy use the downstream protocol (HTTP/1.1 for WS upgrade requests) when connecting to the backend.

Ref #1960