### PR TITLE
fix(automation): add explicit backendRefs to Frigate HTTP route

### DIFF
--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -86,6 +86,10 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
     persistence:
       config:
         enabled: true


### PR DESCRIPTION
Frigate's service exposes multiple ports (http:5000, rtsp:8554,
go2rtc:1984). Without explicit backendRefs, the app-template chart
routes traffic to the wrong backend (go2rtc) instead of Frigate's
HTTP port. Add explicit rules pointing to the app service on the
http port, matching the pattern used by go2rtc and other multi-service
apps.

https://claude.ai/code/session_018MryqwERAGaVY9w6K5VUY1