### PR TITLE
fix: add database credentials and oauth secret to grafana.ini config

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/instance/externalsecret.yaml
@@ -14,9 +14,6 @@ spec:
     template:
       engineVersion: v2
       data:
-        # Grafana Admin
-        GF_SECURITY_ADMIN_PASSWORD: "{{ .GF_SECURITY_ADMIN_PASSWORD }}"
-
         # Postgres Init
         INIT_POSTGRES_DBNAME: &dbName grafana
         INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local

--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -77,11 +77,6 @@ spec:
               env:
                 - name: GF_INSTALL_PLUGINS
                   value: grafana-clock-panel,grafana-piechart-panel,grafana-worldmap-panel,marcusolsson-hourly-heatmap-panel,natel-discrete-panel,natel-plotly-panel,pr0ps-trackmap-panel,vonage-status-panel
-                - name: GF_SECURITY_ADMIN_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: grafana-secret
-                      key: GF_SECURITY_ADMIN_PASSWORD
                 - name: GF_DATABASE_USER
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
The grafana-operator generates `grafana.ini` from `spec.config`, but database user/password/name and the OAuth client secret were only set as container env vars — they weren't in the ini file. This caused:

1. **`grafana-cli` couldn't connect to Postgres** — no DB creds in ini, so admin password reset ran 689 migrations against a fresh SQLite DB instead of the actual Postgres backend
2. **Operator auth failure** — the operator's generated admin password in `grafana-admin-credentials` didn't match the password stored in Postgres (which was from the old Helm chart)
3. **OAuth client_secret missing from ini** — was only set via env var

**Fix:** Add `$ENV_VAR` references in `spec.config.database` and `spec.config.auth.generic_oauth.client_secret` so `grafana.ini` includes them. Grafana expands `$ENV_VAR` references at runtime from the container environment. Also removes the now-unused `GF_SECURITY_ADMIN_PASSWORD` from the ExternalSecret.

After merge, an admin password reset will be needed:
```bash
ADMIN_PASS=$(kubectl get secret grafana-admin-credentials -n observability -o jsonpath='{.data.GF_SECURITY_ADMIN_PASSWORD}' | base64 -d)
kubectl exec -n observability deployment/grafana-deployment -c grafana -- grafana cli --homepath /usr/share/grafana admin reset-admin-password "$ADMIN_PASS"
```