### PR TITLE
fix: add database credentials and oauth secret to grafana.ini config

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -30,6 +30,7 @@ spec:
       name_attribute_path: name
       use_pkce: "true"
       client_id: grafana
+      client_secret: $GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
       api_url: "https://auth.${SECRET_DOMAIN}/api/oidc/userinfo"
       auth_url: "https://auth.${SECRET_DOMAIN}/api/oidc/authorization"
       token_url: "https://auth.${SECRET_DOMAIN}/api/oidc/token"
@@ -39,6 +40,9 @@ spec:
     database:
       type: postgres
       host: postgres-rw.database.svc.cluster.local:5432
+      name: $GF_DATABASE_NAME
+      user: $GF_DATABASE_USER
+      password: $GF_DATABASE_PASSWORD
       ssl_mode: disable
     date_formats:
       use_browser_locale: "false"


### PR DESCRIPTION
The grafana-operator generates `grafana.ini` from `spec.config`, but database user/password/name and the OAuth client secret were only set as container env vars — they weren't in the ini file. This caused:

1. **Operator auth failure** — `grafana-cli` couldn't reset the admin password in Postgres because the ini had no DB creds, so it ran against a throwaway SQLite DB instead
2. **OAuth client_secret missing from ini** — only set as a container env var, not in the config file

**Fix:** Add `\$ENV_VAR` references in `spec.config.database` and `spec.config.auth.generic_oauth.client_secret`. Grafana expands these at runtime from the container environment.

After merge, reset the admin password so the operator can authenticate:
```bash
ADMIN_PASS=$(kubectl get secret grafana-admin-credentials -n observability -o jsonpath='{.data.GF_SECURITY_ADMIN_PASSWORD}' | base64 -d)
kubectl exec -n observability deployment/grafana-deployment -c grafana -- grafana cli --homepath /usr/share/grafana admin reset-admin-password "\$ADMIN_PASS"
```