### PR TITLE
fix: drop postgres for grafana, use sqlite with PVC

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/instance/externalsecret.yaml
@@ -14,21 +14,6 @@ spec:
     template:
       engineVersion: v2
       data:
-        # Postgres Init
-        INIT_POSTGRES_DBNAME: &dbName grafana
-        INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local
-        INIT_POSTGRES_USER: "{{ .GF_DATABASE_USER }}"
-        INIT_POSTGRES_PASS: "{{ .GF_DATABASE_PASSWORD }}"
-        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
-
-        # Grafana Database
-        GF_DATABASE_HOST: postgres-rw.database.svc.cluster.local:5432
-        GF_DATABASE_USER: "{{ .GF_DATABASE_USER }}"
-        GF_DATABASE_PASSWORD: "{{ .GF_DATABASE_PASSWORD }}"
-        GF_DATABASE_NAME: *dbName
-        GF_DATABASE_SSL_MODE: disable
-        GF_DATABASE_TYPE: postgres
-
         # OAuth
         GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "{{ .GRAFANA_OAUTH_CLIENT_SECRET }}"
 
@@ -48,7 +33,5 @@ spec:
         - regexp:
             source: "(.*)"
             target: "TESLAMATE_$1"
-    - extract:
-        key: cloudnative-pg
     - extract:
         key: authelia

--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -37,13 +37,6 @@ spec:
     auth.generic_oauth.group_mapping:
       org_id: "1"
       role_attribute_path: "contains(groups[*], 'admin') && 'Admin' || contains(groups[*], 'people') && 'Viewer'"
-    database:
-      type: postgres
-      host: postgres-rw.database.svc.cluster.local:5432
-      name: $GF_DATABASE_NAME
-      user: $GF_DATABASE_USER
-      password: $GF_DATABASE_PASSWORD
-      ssl_mode: disable
     date_formats:
       use_browser_locale: "false"
       default_timezone: Australia/Sydney
@@ -65,37 +58,15 @@ spec:
       root_url: "https://grafana.${SECRET_DOMAIN}"
   deployment:
     spec:
-      replicas: 2
       strategy:
-        type: RollingUpdate
+        type: Recreate
       template:
         spec:
-          initContainers:
-            - name: 01-init-db
-              image: ghcr.io/home-operations/postgres-init:18.1.0
-              envFrom:
-                - secretRef:
-                    name: grafana-secret
           containers:
             - name: grafana
               env:
                 - name: GF_INSTALL_PLUGINS
                   value: grafana-clock-panel,grafana-piechart-panel,grafana-worldmap-panel,marcusolsson-hourly-heatmap-panel,natel-discrete-panel,natel-plotly-panel,pr0ps-trackmap-panel,vonage-status-panel
-                - name: GF_DATABASE_USER
-                  valueFrom:
-                    secretKeyRef:
-                      name: grafana-secret
-                      key: GF_DATABASE_USER
-                - name: GF_DATABASE_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: grafana-secret
-                      key: GF_DATABASE_PASSWORD
-                - name: GF_DATABASE_NAME
-                  valueFrom:
-                    secretKeyRef:
-                      name: grafana-secret
-                      key: GF_DATABASE_NAME
                 - name: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
                   valueFrom:
                     secretKeyRef:
@@ -111,13 +82,6 @@ spec:
             runAsGroup: 472
             fsGroup: 472
             fsGroupChangePolicy: OnRootMismatch
-          topologySpreadConstraints:
-            - maxSkew: 1
-              topologyKey: kubernetes.io/hostname
-              whenUnsatisfiable: DoNotSchedule
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: grafana
   httpRoute:
     spec:
       hostnames:
@@ -129,4 +93,12 @@ spec:
         - backendRefs:
             - name: grafana-service
               port: 3000
+  persistentVolumeClaim:
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+      storageClassName: ceph-block
   disableDefaultSecurityContext: All

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -34,8 +34,6 @@ spec:
       app.kubernetes.io/name: grafana
   dependsOn:
     - name: grafana
-    - name: cloudnative-pg-cluster
-      namespace: database
     - name: external-secrets-stores
       namespace: external-secrets
   path: ./kubernetes/apps/observability/grafana/instance


### PR DESCRIPTION
Everything is declarative via grafana-operator CRDs (dashboards, datasources, instance config), so Postgres adds unnecessary complexity and was causing operator auth failures (password mismatch between operator-generated secret and existing DB).

**Switch to default SQLite backend with a 10Gi ceph-block PVC for persistence.**

### Changes
- Remove `[database]` config section from Grafana CRD (defaults to SQLite)
- Remove `01-init-db` init container and `GF_DATABASE_*` env vars
- Remove `cloudnative-pg-cluster` dependency from `ks.yaml`
- Remove postgres/init fields from ExternalSecret (keep OAuth + datasource secrets only)
- Add `persistentVolumeClaim` (10Gi ceph-block RWO) for SQLite persistence
- Switch to `Recreate` strategy with single replica (SQLite is single-writer)
- Remove `topologySpreadConstraints` (not needed with 1 replica)

This also fixes the operator auth issue — fresh SQLite means the operator's generated admin password in `grafana-admin-credentials` works on first boot without any manual password reset.