### PR TITLE
fix: set TeslaMate datasource UID and fix postgres credentials

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
@@ -93,7 +93,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: grafana
   valuesFrom:
-    - targetPath: datasource.user
+    - targetPath: datasource.jsonData.user
       valueFrom:
         secretKeyRef:
           name: grafana-secret
@@ -104,11 +104,13 @@ spec:
           name: grafana-secret
           key: TESLAMATE_POSTGRES_PASS
   datasource:
-    type: postgres
+    type: grafana-postgresql-datasource
     name: TeslaMate
+    uid: TeslaMate
     access: proxy
     url: postgres-ro.database.svc.cluster.local:5432
-    database: teslamate
+    isDefault: false
     jsonData:
+      database: teslamate
       postgresVersion: 1000
       sslmode: disable


### PR DESCRIPTION
TeslaMate dashboards all reference `uid: "TeslaMate"` in their JSON, but the GrafanaDatasource CRD had no explicit UID — it got an auto-generated UUID, so every TeslaMate dashboard showed "you do not have a default database configured for this data source".

### Changes
- Set `uid: TeslaMate` on the datasource to match dashboard references
- Set `type: grafana-postgresql-datasource` (correct Grafana plugin ID, was `postgres`)
- Move `user` from `datasource.user` to `datasource.jsonData.user` (where the postgres plugin expects it)
- Set `isDefault: false` explicitly (Prometheus should be the default)