### PR TITLE
fix: correct valuesFrom targetPath for datasource secrets

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
@@ -62,12 +62,12 @@ spec:
     matchLabels:
       app.kubernetes.io/name: grafana
   valuesFrom:
-    - targetPath: datasource.secureJsonData.token
+    - targetPath: "secureJsonData.token"
       valueFrom:
         secretKeyRef:
           name: grafana-secret
           key: GRAFANA_INFLUXDB_TOKEN
-    - targetPath: datasource.jsonData.organization
+    - targetPath: "jsonData.organization"
       valueFrom:
         secretKeyRef:
           name: grafana-secret
@@ -93,18 +93,18 @@ spec:
     matchLabels:
       app.kubernetes.io/name: grafana
   valuesFrom:
-    - targetPath: datasource.jsonData.user
+    - targetPath: "user"
       valueFrom:
         secretKeyRef:
           name: grafana-secret
           key: TESLAMATE_POSTGRES_USER
-    - targetPath: datasource.secureJsonData.password
+    - targetPath: "secureJsonData.password"
       valueFrom:
         secretKeyRef:
           name: grafana-secret
           key: TESLAMATE_POSTGRES_PASS
   datasource:
-    type: grafana-postgresql-datasource
+    type: postgres
     name: TeslaMate
     uid: TeslaMate
     access: proxy


### PR DESCRIPTION
The grafana-operator `valuesFrom` `targetPath` should NOT include the `datasource.` prefix — the path is relative to the datasource object itself.

This was causing InfluxDB token/org and TeslaMate user/password to not be injected into the datasources (they appeared empty in the Grafana API despite the operator reporting success).

### Changes
- Remove `datasource.` prefix from all `valuesFrom.targetPath` values
- InfluxDB: `secureJsonData.token` and `jsonData.organization`
- TeslaMate: `user` and `secureJsonData.password`
- Revert TeslaMate type to `postgres` (matches official operator example)

Ref: https://github.com/grafana/grafana-operator/tree/master/examples/datasource/datasource_variables