### PR TITLE
fix: add variable placeholders for valuesFrom datasource secrets

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
@@ -80,8 +80,11 @@ spec:
     url: http://influxdb.observability.svc.cluster.local:8086
     jsonData:
       version: Flux
+      organization: "${INFLUXDB_ORG_ID}"
       defaultBucket: default
       tlsSkipVerify: true
+    secureJsonData:
+      token: "${GRAFANA_INFLUXDB_TOKEN}"
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadatasource_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -109,8 +112,11 @@ spec:
     uid: TeslaMate
     access: proxy
     url: postgres-ro.database.svc.cluster.local:5432
+    user: "${TESLAMATE_POSTGRES_USER}"
     isDefault: false
     jsonData:
       database: teslamate
       postgresVersion: 1000
       sslmode: disable
+    secureJsonData:
+      password: "${TESLAMATE_POSTGRES_PASS}"


### PR DESCRIPTION
The grafana-operator `valuesFrom` performs **string replacement** on `${VAR}` placeholders — it does NOT directly inject values into the datasource spec. Both the `valuesFrom` entry AND an inline placeholder string are required.

Ref: [datasource_variables example](https://github.com/grafana/grafana-operator/tree/master/examples/datasource/datasource_variables):
> *"The Operator expects a string to be present with the replacement pattern."*

### Changes
- TeslaMate: add `user: \${TESLAMATE_POSTGRES_USER}` and `secureJsonData.password: \${TESLAMATE_POSTGRES_PASS}`
- InfluxDB: add `jsonData.organization: \${INFLUXDB_ORG_ID}` and `secureJsonData.token: \${GRAFANA_INFLUXDB_TOKEN}`