### PR TITLE
fix: escape $${} in datasource valuesFrom placeholders for Flux

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
@@ -80,11 +80,11 @@ spec:
     url: http://influxdb.observability.svc.cluster.local:8086
     jsonData:
       version: Flux
-      organization: "${INFLUXDB_ORG_ID}"
+      organization: "$${INFLUXDB_ORG_ID}"
       defaultBucket: default
       tlsSkipVerify: true
     secureJsonData:
-      token: "${GRAFANA_INFLUXDB_TOKEN}"
+      token: "$${GRAFANA_INFLUXDB_TOKEN}"
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadatasource_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -112,11 +112,11 @@ spec:
     uid: TeslaMate
     access: proxy
     url: postgres-ro.database.svc.cluster.local:5432
-    user: "${TESLAMATE_POSTGRES_USER}"
+    user: "$${TESLAMATE_POSTGRES_USER}"
     isDefault: false
     jsonData:
       database: teslamate
       postgresVersion: 1000
       sslmode: disable
     secureJsonData:
-      password: "${TESLAMATE_POSTGRES_PASS}"
+      password: "$${TESLAMATE_POSTGRES_PASS}"


### PR DESCRIPTION
Flux `postBuild.substituteFrom` processes all `${VAR}` patterns across kustomizations. The grafana-operator `valuesFrom` placeholders like `${TESLAMATE_POSTGRES_USER}` were being consumed by Flux (resolved to null), causing:

```
spec.datasource.user: Invalid value: "null": spec.datasource.user in body must be of type string
```

Fix: use `$${VAR}` which Flux renders as literal `${VAR}`, allowing the grafana-operator to perform its own substitution from the referenced secrets.