### PR TITLE
fix(network): increase envoy proxy replicas to 5 for L2 announcement coverage

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -12,7 +12,7 @@ spec:
     type: Kubernetes
     kubernetes:
       envoyDeployment:
-        replicas: 2
+        replicas: 5
         container:
           # Pin to v1.36 until https://github.com/envoyproxy/gateway/issues/8202 is fixed
           # v1.37 strips Location header on ext_authz denial, breaking auth redirects


### PR DESCRIPTION


With externalTrafficPolicy: Local, Cilium L2 announcements can land on nodes without envoy pods, causing connection refused. Increasing replicas to match node count ensures every node has a local backend.