### PR TITLE
fix(kopia): set repository refresh interval to 5m for web UI

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -36,6 +36,7 @@ spec:
                   name: kopia-secret
             args:
               - --without-password
+              - --refresh-interval=5m
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
The Kopia server defaults to a 4-hour repository refresh interval, meaning new snapshots written by VolSync mover jobs don't appear in the web UI until the server restarts or the cache expires.

Sets `--refresh-interval=5m` so the web UI picks up new snapshots within 5 minutes.