### PR TITLE
fix(kopia): set refresh interval to 5m and increase probe startup tolerance

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -36,6 +36,7 @@ spec:
                   name: kopia-secret
             args:
               - --without-password
+              - --refresh-interval=5m
             probes:
               liveness: &probes
                 enabled: true
@@ -44,10 +45,10 @@ spec:
                   httpGet:
                     path: /
                     port: *port
-                  initialDelaySeconds: 0
+                  initialDelaySeconds: 60
                   periodSeconds: 10
                   timeoutSeconds: 1
-                  failureThreshold: 3
+                  failureThreshold: 5
               readiness: *probes
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
Two fixes for the Kopia web UI server:

1. **`--refresh-interval=5m`** — Kopia defaults to 4h repository refresh, meaning snapshots written by VolSync movers don't appear in the UI. Now refreshes every 5 minutes.

2. **Probe tolerance** — increased `initialDelaySeconds` from 0 to 60 and `failureThreshold` from 3 to 5. The server needs time to scan the NFS repository index on startup; the default probes were killing it before it could finish.