### PR TITLE
feat(kopia): enable debug logging

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -37,19 +37,14 @@ spec:
             args:
               - --without-password
               - --refresh-interval=5m
+              - --log-level=debug
             probes:
-              liveness: &probes
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /
-                    port: *port
-                  initialDelaySeconds: 60
-                  periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 5
-              readiness: *probes
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
Adds `--log-level=debug` to the Kopia server for visibility into repository operations. Probes remain enabled with startup tolerance (60s initial delay, 5 failure threshold).