### PR TITLE
feat(kopia): enable debug logging

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -37,6 +37,7 @@ spec:
             args:
               - --without-password
               - --refresh-interval=5m
+              - --log-level=debug
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
Adds `--log-level=debug` to the Kopia server for visibility into repository operations. Probes remain enabled with startup tolerance (60s initial delay, 5 failure threshold).