### PR TITLE
fix(kopia): run server as root to read mover-created files

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -37,6 +37,7 @@ spec:
             args:
               - --without-password
               - --refresh-interval=5m
+              - --log-level=debug
             probes:
               liveness: &probes
                 enabled: true
@@ -61,8 +62,8 @@ spec:
                 memory: 1Gi
     defaultPodOptions:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 568
+        runAsNonRoot: false
+        runAsUser: 0
         runAsGroup: 568
         fsGroup: 568
         fsGroupChangePolicy: OnRootMismatch


### PR DESCRIPTION
The VolSync Kopia mover writes files as `root:568` with `600` permissions despite `moverSecurityContext.runAsUser: 568`. This means the Kopia web server running as UID 568 cannot read them (owner is root, no group read).

Fix: run the Kopia server as `root:568` so it can read all mover-created files. `allowPrivilegeEscalation: false` and `drop ALL` capabilities are still enforced.