### PR TITLE
fix(kopia): increase maintenance activeDeadlineSeconds to 12h

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
@@ -6,6 +6,7 @@ metadata:
   name: daily
 spec:
   enabled: true
+  activeDeadlineSeconds: 43200
   trigger:
     schedule: 0 */12 * * *
   repository:


### PR DESCRIPTION
First maintenance run timed out at the default 3h deadline. Increase to 12h to allow initial full maintenance to complete.