### PR TITLE
fix(kopia): run maintenance as root to match mover file ownership

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
@@ -7,6 +7,16 @@ metadata:
 spec:
   enabled: true
   activeDeadlineSeconds: 43200
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 568
+    fsGroup: 568
+    runAsNonRoot: false
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
   trigger:
     schedule: 0 */12 * * *
   repository:


### PR DESCRIPTION
The KopiaMaintenance CRD defaults to UID 1000. Since the VolSync mover creates files as `root:568` with `600` permissions, maintenance jobs can't read them.

Sets `podSecurityContext.runAsUser: 0` (matching the Kopia server fix in #2008) so maintenance can access all repository files.