### PR TITLE
chore(container): switch jellyseerr image to ghcr.io/seerr-team/seerr

### DIFF
--- a/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
@@ -27,8 +27,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/fallenbagel/jellyseerr
-              tag: 2.7.3@sha256:9cc9e9ee6cd5cf5a23feb45c37742ba34cfd6314d81d259cddb373a97ac92cdd
+              repository: ghcr.io/seerr-team/seerr
+              tag: v3.0.1@sha256:1b5fc1ea825631d9d165364472663b817a4c58ef6aa1013f58d82c1570d7c866
             env:
               TZ: "Australia/Sydney"
               LOG_LEVEL: info


### PR DESCRIPTION
## Summary
- switch Jellyseerr container image repository to the merged Seerr project
- update to latest GHCR release v3.0.1 with pinned digest
- keep all resource names/config/PVCs unchanged for a like-for-like migration

## Changed file
- kubernetes/apps/media/jellyseerr/app/helmrelease.yaml