### PR TITLE
feat(actions-runner): Add GitHub Actions runner infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ The platform hosts **70+ applications** across multiple categories:
 - **[Metrics Server](https://github.com/kubernetes-sigs/metrics-server)** - Resource usage metrics
 - **[Tuppr](https://github.com/home-operations/tuppr)** - Automated Talos Linux and Kubernetes upgrades
 
+### 🤖 CI/CD & Automation
+- **[Actions Runner Controller](https://github.com/actions/actions-runner-controller)** - Self-hosted GitHub Actions runners
+  - Enables image pre-pulling to Talos nodes via `talosctl`
+  - Scales 0-3 runners dynamically based on workflow demand
+  - Authenticates via GitHub App with cluster-admin and os:admin permissions
+
 ---
 
 ## 🏛️ Architecture
@@ -296,6 +302,7 @@ Complete cluster rebuild capability:
 ```
 📁 kubernetes/
 ├── 📁 apps/              # Application deployments organized by namespace
+│   ├── 📁 actions-runner-system/ # Self-hosted GitHub Actions runners
 │   ├── 📁 automation/    # Home automation stack
 │   ├── 📁 cert-manager/  # Certificate management
 │   ├── 📁 database/      # Database services

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app actions-runner-controller
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set-controller
+  interval: 1h
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    fullnameOverride: *app

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set-controller
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.13.1
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app actions-runner-controller
+  namespace: flux-system
+spec:
+  targetNamespace: actions-runner-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: actions-runner-controller-runners
+  namespace: flux-system
+spec:
+  targetNamespace: actions-runner-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: actions-runner-controller-runners
+  dependsOn:
+    - name: actions-runner-controller
+    - name: openebs
+      namespace: flux-system
+  interval: 1h
+  path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-ops-runner
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: home-ops-runner-secret
+    template:
+      data:
+        github_app_id: '{{ .ACTIONS_RUNNER_APP_ID }}'
+        github_app_installation_id: '{{ .ACTIONS_RUNNER_INSTALLATION_ID }}'
+        github_app_private_key: '{{ .ACTIONS_RUNNER_PRIVATE_KEY }}'
+  dataFrom:
+    - extract:
+        key: actions-runner

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app home-ops-runner
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set
+  interval: 1h
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    githubConfigUrl: https://github.com/adampetrovic/home-ops
+    githubConfigSecret: home-ops-runner-secret
+    
+    # Scaling configuration
+    minRunners: 0  # Scale to zero when idle
+    maxRunners: 3  # Max concurrent runners
+    
+    # Use Kubernetes container mode
+    containerMode:
+      type: kubernetes
+      kubernetesModeWorkVolumeClaim:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: openebs-hostpath
+        resources:
+          requests:
+            storage: 25Gi
+    
+    # Reference to the controller ServiceAccount
+    controllerServiceAccount:
+      name: actions-runner-controller
+      namespace: actions-runner-system
+    
+    # Runner pod template
+    template:
+      spec:
+        containers:
+          - name: runner
+            # Using official GitHub Actions runner image
+            # Workflows will install talosctl on-demand
+            image: ghcr.io/actions/actions-runner:latest
+            command:
+              - /home/runner/run.sh
+            env:
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+              - name: NODE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.hostIP
+            volumeMounts:
+              - mountPath: /var/run/secrets/talos.dev
+                name: talos
+                readOnly: true
+        
+        serviceAccountName: *app
+        
+        volumes:
+          - name: talos
+            secret:
+              secretName: *app

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.13.1
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/rbac.yaml
@@ -1,0 +1,29 @@
+---
+# Kubernetes ServiceAccount for the runner pods
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: home-ops-runner
+---
+# Grant cluster-admin to runner pods (needed for kubectl operations)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: home-ops-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: home-ops-runner
+    namespace: actions-runner-system
+---
+# Talos ServiceAccount - generates talosconfig secret automatically
+apiVersion: talos.dev/v1alpha1
+kind: ServiceAccount
+metadata:
+  name: home-ops-runner
+spec:
+  roles:
+    - os:admin

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./home-ops

--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: actions-runner-system
+components:
+  - ../../components/common
+resources:
+  - ./namespace.yaml
+  - ./actions-runner-controller/ks.yaml

--- a/kubernetes/apps/actions-runner-system/namespace.yaml
+++ b/kubernetes/apps/actions-runner-system/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: actions-runner-system
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
Deploys actions-runner-controller with self-hosted runners for home-ops.

Features:
- Controller manages runner lifecycle (scales 0-3)
- Talos ServiceAccount auto-generates talosconfig for node access
- GitHub App authentication via ExternalSecret (1Password)
- cluster-admin + os:admin permissions for kubectl and talosctl
- openebs-hostpath storage for runner workspace (25Gi)

This enables the image pre-pull workflow (see issue #1450) where runners can pull container images to Talos nodes before PR merge, reducing pod startup time.

Includes documentation:
- RUNDOWN-github-actions-runner.md (deployment guide)
- HOWTO-generate-runner-secrets.md (GitHub App setup)
- PLAN-image-pull-workflow.md (next steps)