### PR TITLE
test: Trigger image pre-pull workflow

### DIFF
--- a/kubernetes/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo-server/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mendhak/http-https-echo
-              tag: 39
+              tag: 40
             env:
               HTTP_PORT: &port 8080
               LOG_WITHOUT_NEWLINE: true


### PR DESCRIPTION
Testing the image pre-pull workflow by updating echo-server image tag.

This PR should trigger the image-pull workflow which will:
1. Detect the changed image (echo-server 39 → 40)
2. Spawn a runner pod
3. Pull the image to one Talos node
4. Spegel distributes to remaining nodes

Watch the workflow: https://github.com/adampetrovic/home-ops/actions/workflows/image-pull.yaml