### PR TITLE
fix(talos): use correct containerd v2 path for discard_unpacked_layers

### DIFF
--- a/talos/patches/global/machine-files.yaml
+++ b/talos/patches/global/machine-files.yaml
@@ -3,10 +3,8 @@ machine:
     - op: create
       path: /etc/cri/conf.d/20-customization.part
       content: |-
+        [plugins."io.containerd.cri.v1.images"]
+          discard_unpacked_layers = false
         [plugins."io.containerd.grpc.v1.cri"]
           enable_unprivileged_ports = true
           enable_unprivileged_icmp = true
-        [plugins."io.containerd.grpc.v1.cri".containerd]
-          discard_unpacked_layers = false
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-          discard_unpacked_layers = false


### PR DESCRIPTION
## Summary

The `discard_unpacked_layers = false` setting was under the legacy `io.containerd.grpc.v1.cri` plugin path, which containerd v2 (config version 3) ignores. The Talos base config (`00-base.part`) sets `discard_unpacked_layers = true` under the correct `io.containerd.cri.v1.images` path, so our override was never taking effect.

This moves the setting to the correct path so that containerd retains raw layer blobs in the content store after unpacking, enabling Spegel P2P image distribution to serve layers to peer nodes.

## Changes

- `talos/patches/global/machine-files.yaml`: Replace legacy `io.containerd.grpc.v1.cri` containerd config with correct `io.containerd.cri.v1.images` path
- Remove stale `discard_unpacked_layers` entries from the old plugin paths

## Testing

- Verified merged `cri.toml` on all 5 nodes shows `discard_unpacked_layers = false` under the correct path
- Confirmed Spegel P2P serves images between nodes (5 cache hits for busybox:1.37 pull from node-1 to node-2 in 391ms)
- Already applied to all nodes (required reboot)