### PR TITLE
fix(immich): increase machine-learning memory limits to prevent OOM

### DIFF
--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -126,9 +126,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 1536Mi
-              limits:
                 memory: 2Gi
+              limits:
+                memory: 4Gi
         pod:
           securityContext:
             runAsUser: 568


### PR DESCRIPTION
## Problem

The Immich machine-learning container has been repeatedly OOMKilled (3 restarts, exit code 137). The container loads multiple ML models simultaneously during photo processing:

- **CLIP ViT-B-32** (~600-800MB) — visual search embeddings
- **buffalo_l** (~500-700MB) — face detection + recognition
- **PP-OCRv5** (~200-300MB) — OCR text extraction
- **Python/ONNX runtime overhead** (~300-500MB)

Combined memory footprint during concurrent inference exceeds the previous **2Gi limit**.

## Evidence

```
Last State:     Terminated
  Reason:       OOMKilled
  Exit Code:    137
Restart Count:  3
```

Previous container logs show all models being downloaded and loaded into memory simultaneously before OOM.

## Fix

| Resource | Before | After |
|----------|--------|-------|
| requests.memory | 1536Mi | 2Gi |
| limits.memory | 2Gi | **4Gi** |

4Gi provides comfortable headroom for all models loaded concurrently with inference workloads.