### PR TITLE
feat(media): add sportarr

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ./shelfmark/ks.yaml
   - ./sonarr/ks.yaml
   - ./sonarr-4k/ks.yaml
+  - ./sportarr/ks.yaml
   - ./stash/ks.yaml
   - ./tautulli/ks.yaml
   - ./tracearr/ks.yaml

--- a/kubernetes/apps/media/sportarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sportarr/app/helmrelease.yaml
@@ -1,0 +1,106 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: sportarr
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 2
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      sportarr:
+        annotations:
+          reloader.stakater.com/auto: 'true'
+        containers:
+          app:
+            image:
+              repository: mirror.gcr.io/sportarr/sportarr
+              tag: latest@sha256:bd915451e072d48094b8fb5a0ac46f36b90397ce5cb0e152c219cbab379e1921
+            command: [dotnet, /app/Sportarr.dll]
+            env:
+              TZ: "${TZ}"
+              HOME: /config
+              Sportarr__DataPath: /config
+              DOTNET_BUNDLE_EXTRACT_BASE_DIR: /tmp/dotnet
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: &port 1867
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+        pod:
+          securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            runAsNonRoot: true
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            supplementalGroups: [100]
+    service:
+      app:
+        controller: sportarr
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - sportarr.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      config:
+        enabled: true
+        existingClaim: sportarr
+        globalMounts:
+          - path: /config
+      data:
+        type: nfs
+        server: ${SECRET_NFS_DOMAIN}
+        path: /volume2/sports
+        globalMounts:
+          - path: /data
+      downloads:
+        type: nfs
+        server: ${SECRET_NFS_DOMAIN}
+        path: /volume2/downloads
+        globalMounts:
+          - path: /downloads
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/sportarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/sportarr/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/sportarr/ks.yaml
+++ b/kubernetes/apps/media/sportarr/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app sportarr
+  namespace: &namespace media
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/media/sportarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # no flux ks dependents
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_KOPIA_SCHEDULE: "26 * * * *"
+      VOLSYNC_R2_SCHEDULE: "12 5 * * *"


### PR DESCRIPTION
## Summary\n- deploy Sportarr in the media namespace using app-template\n- expose it internally at sportarr.${SECRET_DOMAIN}\n- back up config with VolSync and mount sports storage from /volume2/sports\n\n## Validation\n- yq e '.' on changed YAML files\n- kustomize build kubernetes/apps/media/sportarr/app\n- kustomize build kubernetes/apps/media\n- flux build kustomization sportarr -n media --dry-run\n- helm template app-template 4.6.2\n