### PR TITLE
fix(automation): update go2rtc-split controls

### DIFF
--- a/kubernetes/apps/automation/go2rtc-split/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/go2rtc-split/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           app:
             image:
               repository: ghcr.io/adampetrovic/go2rtc-split
-              tag: v0.1.0@sha256:2caf039074a6950cb7853e0904e035f17b6052b2b94c3252b4945ef157d4c2f8
+              tag: v0.1.2@sha256:817f3c1c35603c46ec015e7b7ccdf9eb8f38583e8afc467d274789f1d26e2ae3
             env:
               TZ: ${TZ}
               PORT: "8080"


### PR DESCRIPTION
## Summary\n- update go2rtc-split to v0.1.2\n- includes local layout fix for overlapping stream/global/audio controls\n\n## Local validation before release\n- npm run check/test/build in go2rtc-split\n- production server at http://127.0.0.1:18080/split/ with Zoey/Eliza runtime config\n- headless Chrome visual layout test at 1507x825@2x: panel bottom controls vs audio prompt/global controls gap 23px, overlap=false\n- screenshot: /tmp/go2rtc-split-local-layout-v0.1.2.png\n\n## home-ops validation\n- helm template app-template 4.6.2 for go2rtc-split\n- skopeo inspect v0.1.2 image digest for linux/amd64 and linux/arm64