### PR TITLE
fix(automation): simplify go2rtc-split controls

### DIFF
--- a/kubernetes/apps/automation/go2rtc-split/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/go2rtc-split/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           app:
             image:
               repository: ghcr.io/adampetrovic/go2rtc-split
-              tag: v0.1.2@sha256:817f3c1c35603c46ec015e7b7ccdf9eb8f38583e8afc467d274789f1d26e2ae3
+              tag: v0.1.3@sha256:bf5df48493a6d0c42ab84c4a082958ec0a3039bec8bff88ead94a3e4dca2594d
             env:
               TZ: ${TZ}
               PORT: "8080"
@@ -45,8 +45,9 @@ spec:
               AUDIO_MODE: mixed
               START_MUTED: "false"
               DEFAULT_VOLUME: "1"
-              AUDIO_METERS: "true"
-              SHOW_CONTROLS: "true"
+              AUDIO_METERS: "false"
+              AUDIO_UNLOCK_PROMPT: "false"
+              SHOW_CONTROLS: "false"
               SHOW_STATUS: "true"
               WAKE_LOCK: "true"
               FULLSCREEN_BUTTON: "true"


### PR DESCRIPTION
## Summary\n- update go2rtc-split to v0.1.3\n- disable stream/global controls except fullscreen\n- disable audio meters and audio unlock prompt\n- retain fullscreen button; app hides it after fullscreen is entered\n\n## Upstream local validation before release\n- npm run check/test/build in go2rtc-split\n- production server at http://127.0.0.1:18080/split/ with runtime config matching this deployment\n- headless Chrome layout test: visibleButtons=[Fullscreen], audioPrompt=null, panel/global gap 22px, overlap=false\n- headless Chrome gesture test: pointer pinch applies video transform scale(1.5), zoomed=true\n\n## home-ops validation\n- helm template app-template 4.6.2 for go2rtc-split\n- skopeo inspect v0.1.3 image digest for linux/amd64 and linux/arm64