### PR TITLE
feat(ai): deploy pi telegram agent

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+components:
+  - ../../components/common
+resources:
+  - ./pi-telegram-agent/ks.yaml

--- a/kubernetes/apps/ai/pi-telegram-agent/app/config/settings.json
+++ b/kubernetes/apps/ai/pi-telegram-agent/app/config/settings.json
@@ -1,0 +1,8 @@
+{
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.5",
+  "defaultThinkingLevel": "xhigh",
+  "enableInstallTelemetry": false,
+  "packages": [],
+  "sessionDir": "/config/.pi/agent/sessions"
+}

--- a/kubernetes/apps/ai/pi-telegram-agent/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/pi-telegram-agent/app/externalsecret.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pi-telegram-agent
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: pi-telegram-agent-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      data:
+        config.yaml: |
+          telegram:
+            bot_token: "{{ .TELEGRAM_BOT_TOKEN }}"
+            chat_id: {{ .TELEGRAM_CHAT_ID }}
+
+          pi:
+            cwd: /config
+            model: openai-codex/gpt-5.5
+            session_dir: /config/.local/share/pi-telegram-bot/sessions
+
+          log_level: info
+  data:
+    - secretKey: TELEGRAM_BOT_TOKEN
+      remoteRef:
+        key: telegram
+        property: TELEGRAM_BOT_TOKEN
+    - secretKey: TELEGRAM_CHAT_ID
+      remoteRef:
+        key: telegram
+        property: TELEGRAM_CHAT_ID

--- a/kubernetes/apps/ai/pi-telegram-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/pi-telegram-agent/app/helmrelease.yaml
@@ -1,0 +1,105 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app pi-telegram-agent
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-private
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      pi-telegram-agent:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        containers:
+          agent:
+            image:
+              repository: ghcr.io/adampetrovic/pi-telegram-bot
+              tag: v1.0.16@sha256:f8ff716f71b732ffccf0f0f1642c0b12a2db6c5bb5a3d1d64b573f7f707571a7
+            env:
+              TZ: ${TZ}
+              HOME: /config
+              PI_BIN: pi
+              PI_CODING_AGENT_DIR: /config/.pi/agent
+              PI_TELEGRAM_BOT_CONFIG: /config/pi-telegram-bot/config.yaml
+              PI_TELEGRAM_SUMMARIZER_MODEL: openai-codex/gpt-5.4-mini
+              PI_SKIP_VERSION_CHECK: "1"
+              PI_TELEMETRY: "0"
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    persistence:
+      code:
+        existingClaim: *app
+        globalMounts:
+          - path: /config/code
+            subPath: code
+      pi-agent:
+        existingClaim: *app
+        globalMounts:
+          - path: /config/.pi/agent
+            subPath: pi-agent
+      pi-telegram-sessions:
+        existingClaim: *app
+        globalMounts:
+          - path: /config/.local/share/pi-telegram-bot/sessions
+            subPath: pi-telegram-bot-sessions
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      pi-config:
+        type: configMap
+        name: pi-telegram-agent-configmap
+        globalMounts:
+          - path: /config/.pi/agent/settings.json
+            subPath: settings.json
+            readOnly: true
+      bot-config:
+        type: secret
+        name: pi-telegram-agent-secret
+        globalMounts:
+          - path: /config/pi-telegram-bot/config.yaml
+            subPath: config.yaml
+            readOnly: true

--- a/kubernetes/apps/ai/pi-telegram-agent/app/kustomization.yaml
+++ b/kubernetes/apps/ai/pi-telegram-agent/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: pi-telegram-agent-configmap
+    files:
+      - ./config/settings.json
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/ai/pi-telegram-agent/ks.yaml
+++ b/kubernetes/apps/ai/pi-telegram-agent/ks.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pi-telegram-agent
+  namespace: &namespace ai
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/ai/pi-telegram-agent/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # no flux ks dependents
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 20Gi
+      VOLSYNC_KOPIA_SCHEDULE: "41 * * * *"
+      VOLSYNC_R2_SCHEDULE: "53 3 * * *"


### PR DESCRIPTION
## Summary\n- add an ai namespace with a basic pi-telegram-agent deployment\n- run the published ghcr.io/adampetrovic/pi-telegram-bot:v1.0.16 image pinned by digest\n- mount /config-backed PVC storage for Pi state, sessions, and repo workspace\n- render only the Telegram bot config from ExternalSecret; no auth.json/API key handling\n- add settings.json via ConfigMap\n\n## Validation\n- kustomize build kubernetes/apps/ai\n- kustomize build kubernetes/apps/ai/pi-telegram-agent/app\n- helm template pi-telegram-agent oci://ghcr.io/bjw-s-labs/helm/app-template --version 4.6.2 -n ai -f /tmp/pi-agent-values.yaml\n