### PR TITLE
fix(ai): mount writable Pi home directories

### DIFF
--- a/kubernetes/apps/ai/pi-telegram-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/pi-telegram-agent/app/helmrelease.yaml
@@ -75,6 +75,21 @@ spec:
         globalMounts:
           - path: /config/code
             subPath: code
+      ssh:
+        existingClaim: *app
+        globalMounts:
+          - path: /config/.ssh
+            subPath: ssh
+      cache:
+        existingClaim: *app
+        globalMounts:
+          - path: /config/.cache
+            subPath: cache
+      home-config:
+        existingClaim: *app
+        globalMounts:
+          - path: /config/.config
+            subPath: config
       pi-agent:
         existingClaim: *app
         globalMounts:


### PR DESCRIPTION
## Summary\n- mount writable PVC-backed home subdirectories under /config for the Pi Telegram agent\n- fixes the crashloop caused by the image entrypoint trying to create /config/.ssh on a read-only root filesystem\n- also provides writable /config/.cache and /config/.config for common CLI state\n\n## Validation\n- kustomize build kubernetes/apps/ai\n- helm template pi-telegram-agent oci://ghcr.io/bjw-s-labs/helm/app-template --version 4.6.2 -n ai -f /tmp/pi-agent-values.yaml\n