### PR TITLE
fix(ai): use pi telegram agent credentials

### DIFF
--- a/kubernetes/apps/ai/pi-telegram-agent/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/pi-telegram-agent/app/externalsecret.yaml
@@ -29,9 +29,9 @@ spec:
   data:
     - secretKey: TELEGRAM_BOT_TOKEN
       remoteRef:
-        key: telegram
+        key: pi-telegram-agent
         property: TELEGRAM_BOT_TOKEN
     - secretKey: TELEGRAM_CHAT_ID
       remoteRef:
-        key: telegram
+        key: pi-telegram-agent
         property: TELEGRAM_CHAT_ID


### PR DESCRIPTION
## Summary
- add/use a dedicated k8s 1Password Login item named `pi-telegram-agent` for the Pi Telegram bot credentials
- update the Pi Telegram agent ExternalSecret to read `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` from that item instead of the shared `telegram` item

## Validation
- `kustomize build kubernetes/apps/ai`
- verified 1Password item exists in the `k8s` vault with `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` fields
