### PR TITLE
fix(automation): update go2rtc-split focus UX

### DIFF
--- a/kubernetes/apps/automation/go2rtc-split/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/go2rtc-split/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           app:
             image:
               repository: ghcr.io/adampetrovic/go2rtc-split
-              tag: v0.1.4@sha256:3aa318247602aa024f51b3f163ab4df0994836b1b6037e59ef491cf598e2bb0b
+              tag: v0.1.5@sha256:6899e3a8385c83345998868b159e3f69367533a6de2fd071677fd183820cefa5
             env:
               TZ: ${TZ}
               PORT: "8080"
@@ -51,6 +51,8 @@ spec:
               SHOW_STATUS: "true"
               WAKE_LOCK: "true"
               FULLSCREEN_BUTTON: "true"
+              DOCUMENT_FULLSCREEN_BUTTON: "false"
+              STREAM_FULLSCREEN_BUTTON: "true"
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
## Summary\n- update go2rtc-split to v0.1.5\n- enable per-stream PWA-safe focus/fullscreen buttons\n- disable the document fullscreen button for the installed-PWA monitor use case\n\n## Upstream local validation before release\n- npm run check/test/build in go2rtc-split\n- production server at http://127.0.0.1:18080/split/ with runtime config matching this deployment\n- headless Chrome UI test: split buttons=[Full screen, Full screen], focus mode shows one stream with Split view, exit returns two streams\n- headless Chrome gesture test: pinch/pointer zoom applies scale(1.5), zoomed=true\n- screenshot: /tmp/go2rtc-split-v0.1.5-local.png\n\n## home-ops validation\n- helm template app-template 4.6.2 for go2rtc-split\n- skopeo inspect v0.1.5 image digest for linux/amd64 and linux/arm64