### PR TITLE
feat(gdb): enable gdb app

### DIFF
--- a/kubernetes/apps/gdb/gdb/app/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/adampetrovic/gdb-web
-              tag: 1.10.20@sha256:c14ec7803325eeba9286a790a06eb7b5bd4412d885fcb68a44fc19a9d6f3434e
+              tag: 1.10.22@sha256:dba1306c61d7d3e0a93c104dc4f9e525d3844f62f5513aa6b7057d5b212b2caf
               pullPolicy: Always
             env:
               SERVER_HOST: "0.0.0.0"

--- a/kubernetes/apps/gdb/gdb/ks.yaml
+++ b/kubernetes/apps/gdb/gdb/ks.yaml
@@ -6,7 +6,6 @@ metadata:
   name: &app gdb
   namespace: &namespace gdb
 spec:
-  suspend: true
   targetNamespace: *namespace
   commonMetadata:
     labels:


### PR DESCRIPTION
## Summary
- unsuspend the restored `gdb` Flux Kustomization so the web app can deploy
- bump `gdb-web` to `1.10.22`
- keep scraper CronJobs suspended for the controlled backfill phase

## Pre-deploy
- fresh `gdb-postgres` CNPG cluster is healthy
- `gdb-secret` now syncs from 1Password
- migrations were run out-of-band from `~/code/gdb-web`

## Validation
- `kustomize build kubernetes/apps/gdb`
- `flux build kustomization cluster-apps -n flux-system --path ./kubernetes/apps --recursive --local-sources GitRepository/flux-system/flux-system=.`
