### PR TITLE
fix(mqtt): persist retained broker state

### DIFF
--- a/kubernetes/apps/automation/home-assistant/ks.yaml
+++ b/kubernetes/apps/automation/home-assistant/ks.yaml
@@ -19,7 +19,7 @@ spec:
       namespace: rook-ceph
     - name: multus-config
       namespace: network
-    - name: zigbee2mqtt
+    - name: mosquitto
       namespace: automation
   path: ./kubernetes/apps/automation/home-assistant/app
   prune: true

--- a/kubernetes/apps/automation/mosquitto/README.md
+++ b/kubernetes/apps/automation/mosquitto/README.md
@@ -1,0 +1,53 @@
+# Mosquitto retained MQTT state
+
+Mosquitto is configured with persistence enabled so retained MQTT messages survive broker pod and node restarts. This prevents Home Assistant from missing retained discovery, state, and availability messages when large upgrades restart `mosquitto`, Home Assistant, Zigbee2MQTT, Sigenergy2MQTT, or LAN MQTT clients such as Shelly1 devices in an unlucky order.
+
+This persists topics that clients already publish with the MQTT retain flag; it does not make every MQTT message retained.
+
+## Why not only use dependencies?
+
+Flux dependencies help with GitOps reconciliation order, but they do not cover all failure modes:
+
+- Talos upgrades and node drains can evict pods outside Flux dependency ordering.
+- Home Assistant can restart by itself after publishers have already emitted non-retained availability messages.
+- LAN MQTT clients such as Shelly devices are outside Kubernetes and cannot be ordered with Flux.
+- Broker restarts clear in-memory retained messages unless Mosquitto persistence is enabled.
+
+Keep dependencies for coarse startup ordering, but use retained state for correctness.
+
+## What should be retained
+
+Use retained messages deliberately:
+
+- Home Assistant MQTT discovery topics (`homeassistant/#`).
+- Normal state topics where last-known-state is useful.
+- Availability topics only when the client also publishes a matching retained `offline` message via Last Will or a clean shutdown path.
+
+Do **not** retain command, action, or one-shot event topics such as `.../set`, `.../command`, button events, or transient actions.
+
+## Downsides to watch for
+
+- A stale retained `online` message can make Home Assistant show a device as available after the device has died if there is no matching retained `offline`/LWT behaviour.
+- Retained discovery topics can create ghost entities after device renames or removals until the retained discovery config is cleared.
+- Retained state can make old sensor values appear immediately after a Home Assistant restart; use availability or `expire_after` where stale data is unsafe.
+- Retained MQTT payloads are now written to the Mosquitto PVC. This PVC is intentionally not backed up by VolSync.
+
+Clear a bad retained topic by publishing a zero-length retained payload. Mosquitto requires authentication; load `MQTT_USERNAME` and `MQTT_PASSWORD` from the `mosquitto-secret` Kubernetes Secret or 1Password first.
+
+```bash
+mosquitto_pub -h mqtt.${SECRET_DOMAIN} -u "$MQTT_USERNAME" -P "$MQTT_PASSWORD" -r -n -t '<topic>'
+```
+
+## Validation after upgrades
+
+Check retained topics before and after restarting Mosquitto and Home Assistant:
+
+```bash
+mosquitto_sub -h mqtt.${SECRET_DOMAIN} -u "$MQTT_USERNAME" -P "$MQTT_PASSWORD" --retained-only -t 'homeassistant/#' -v
+mosquitto_sub -h mqtt.${SECRET_DOMAIN} -u "$MQTT_USERNAME" -P "$MQTT_PASSWORD" --retained-only -t 'zigbee2mqtt/#' -v
+mosquitto_sub -h mqtt.${SECRET_DOMAIN} -u "$MQTT_USERNAME" -P "$MQTT_PASSWORD" --retained-only -t 'sigenergy2mqtt/#' -v
+mosquitto_sub -h mqtt.${SECRET_DOMAIN} -u "$MQTT_USERNAME" -P "$MQTT_PASSWORD" --retained-only -t 'shellies/#' -v
+mosquitto_sub -h mqtt.${SECRET_DOMAIN} -u "$MQTT_USERNAME" -P "$MQTT_PASSWORD" --retained-only -t 'shelly/#' -v
+```
+
+Shelly Gen1 devices commonly use `shellies/<device-id>/...`; newer devices or custom configurations may use a different prefix.

--- a/kubernetes/apps/automation/mosquitto/app/config/mosquitto.conf
+++ b/kubernetes/apps/automation/mosquitto/app/config/mosquitto.conf
@@ -1,7 +1,8 @@
 per_listener_settings false
 listener 1883
 allow_anonymous false
-persistence false
-autosave_interval 1800
+persistence true
+persistence_location /mosquitto/data/
+autosave_interval 60
 connection_messages false
 password_file /mosquitto/external_config/mosquitto_pwd

--- a/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
@@ -41,6 +41,18 @@ spec:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
+            probes:
+              liveness: &mqttProbe
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 1883
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *mqttProbe
             resources:
               requests:
                 cpu: 10m
@@ -88,3 +100,10 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /mosquitto/external_config
+      data:
+        enabled: true
+        storageClass: ceph-block
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        globalMounts:
+          - path: /mosquitto/data

--- a/kubernetes/apps/automation/mosquitto/ks.yaml
+++ b/kubernetes/apps/automation/mosquitto/ks.yaml
@@ -10,6 +10,8 @@ spec:
   dependsOn:
     - name: external-secrets-stores
       namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app


### PR DESCRIPTION
## Summary
- enable Mosquitto persistence and mount a chart-managed `ceph-block` PVC at `/mosquitto/data` so retained MQTT messages survive broker pod/node restarts
- intentionally avoid VolSync/backups for this retained-state cache
- add TCP liveness/readiness probes for the MQTT listener
- make Home Assistant depend directly on Mosquitto instead of Zigbee2MQTT, reducing upgrade-order coupling
- add a Mosquitto retained-state runbook covering dependency limitations, retained-message downsides, cleanup, and validation for Home Assistant, Zigbee2MQTT, Sigenergy2MQTT, and Shelly topics

## Why
This addresses `TODO-c530c553`: during large upgrades, Home Assistant can miss MQTT availability messages if publishers or the broker restart in an unlucky order. Dependencies help with GitOps ordering, but they cannot cover Talos node drains, Home Assistant-only restarts, external LAN MQTT clients, or broker restarts that clear in-memory retained messages. Persisting Mosquitto retained state makes discovery/state/availability durable instead of relying on workload ordering alone.

## Validation
- `yq e '.' kubernetes/apps/automation/mosquitto/ks.yaml >/dev/null`
- `yq e '.' kubernetes/apps/automation/mosquitto/app/helmrelease.yaml >/dev/null`
- `yq e '.' kubernetes/apps/automation/home-assistant/ks.yaml >/dev/null`
- `kustomize build kubernetes/apps/automation/mosquitto/app >/tmp/mosquitto-app.yaml`
- `flux -n automation build kustomization mosquitto --path ./kubernetes/apps/automation/mosquitto/app --kustomization-file ./kubernetes/apps/automation/mosquitto/ks.yaml --dry-run >/tmp/mosquitto-flux.yaml`
- `flux -n automation build kustomization home-assistant --path ./kubernetes/apps/automation/home-assistant/app --kustomization-file ./kubernetes/apps/automation/home-assistant/ks.yaml --dry-run >/tmp/home-assistant-flux.yaml`

## Follow-up
- verify retained availability behaviour for Zigbee2MQTT, Sigenergy2MQTT, and Shelly1 devices after this rolls out
- add Home Assistant MQTT birth/will retention in `hass-config` if it is not already configured there
