### PR TITLE
fix(gdb): update scraper image to 0.1.60

### DIFF
--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           scraper:
             image: &image
               repository: ghcr.io/adampetrovic/gdb-scraper
-              tag: 0.1.59@sha256:2e1550216dfa7539529067cfe2c05d1a0e96de020ff6405819ff5be58342b7a1
+              tag: 0.1.60@sha256:9172be439407d82702573769e08e47099ed579db5cb5d154e3e4650403b4eb1c
             envFrom:
               - secretRef:
                   name: gdb-secret


### PR DESCRIPTION
## Summary\n- update gdb scraper CronJobs to v0.1.60\n- includes MMS nickname matching, invalid state-code filtering, and safer geo mismatch handling\n\n## Testing\n- gdb-scraper CI passed for v0.1.60\n- local: poetry run pytest -q (78 passed)