### PR TITLE
fix(gdb): update scraper image to 0.1.61

### DIFF
--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           scraper:
             image: &image
               repository: ghcr.io/adampetrovic/gdb-scraper
-              tag: 0.1.60@sha256:9172be439407d82702573769e08e47099ed579db5cb5d154e3e4650403b4eb1c
+              tag: 0.1.61@sha256:6a83aed8fcbf51a76a41656f27eaef87b706555d5229f24cdc0704eafd3c6f7a
             envFrom:
               - secretRef:
                   name: gdb-secret

--- a/kubernetes/apps/gdb/gdb/scraper/pvc.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/pvc.yaml
@@ -7,5 +7,5 @@ spec:
   accessModes: ["ReadWriteMany"]
   resources:
     requests:
-      storage: 5Gi
+      storage: 50Gi
   storageClassName: ceph-filesystem


### PR DESCRIPTION
## Summary\n- update gdb scraper CronJobs to v0.1.61\n- expand gdb-scraper RWX PVC from 5Gi to 50Gi for MMS item/HTTP cache artifacts\n\n## Notes\n- v0.1.61 adds optional JSONL item exports, PVC-backed HTTP cache policy for old MMS meet/list pages, and item replay tooling\n\n## Testing\n- gdb-scraper CI passed for v0.1.61\n- local: poetry run pytest -q (81 passed)