### PR TITLE
feat(gdb): add MMS raw cache replay job

### DIFF
--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           scraper:
             image: &image
               repository: ghcr.io/adampetrovic/gdb-scraper
-              tag: 0.1.64@sha256:57f6651a3b8543a1d69876f7ca80b346d512ead97cc5b5624807fde1c24419e1
+              tag: 0.1.70@sha256:232c9029bc4861eb3738714070d54c4ade62b8cd1afacbc69252b9ac59545b19
             envFrom:
               - secretRef:
                   name: gdb-secret
@@ -57,6 +57,43 @@ spec:
                 memory: 3Gi
               limits:
                 memory: 4Gi
+        pod:
+          restartPolicy: Never
+          securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            supplementalGroups: [100]
+      mms-raw-replay:
+        type: cronjob
+        cronjob:
+          schedule: "0 0 1 1 *"      # Manual only: create Job from this suspended CronJob
+          timeZone: "Australia/Sydney"
+          suspend: true
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+        containers:
+          scraper:
+            image: *image
+            envFrom:
+              - secretRef:
+                  name: gdb-secret
+            env:
+              OUTPUT_DIR: /export
+              SOURCE: mms
+              MODE: full
+              MMS_CACHE_MODE: replay-cache
+              MMS_CACHE_DIR: /export/mms-cache/raw
+              YEARS: "2025,2024,2023,2022,2021,2020,2019,2018,2017,2016,2015,2014,2013,2012,2011,2010,2009,2008,2007,2006,2005,2004,2003,2002,2001,2000"
+              GDB_DISABLE_NETWORK_FETCHES: "true"
+              MMS_OFFLINE_REPLAY: "true"
+            resources:
+              requests:
+                memory: 12Gi
+              limits:
+                memory: 24Gi
         pod:
           restartPolicy: Never
           securityContext:


### PR DESCRIPTION
## Summary
- update gdb-scraper image to 0.1.70 with MMS raw-cache replay support
- add suspended `mms-raw-replay` CronJob for offline import from `/export/mms-cache/raw`
- force replay mode offline with `GDB_DISABLE_NETWORK_FETCHES=true` and `MMS_OFFLINE_REPLAY=true`

## Validation
- `kubectl kustomize kubernetes/apps/gdb/gdb/scraper`
- raw MMS cache copied to PVC at `/export/mms-cache/raw`
