### PR TITLE
chore(todo): close Envoy BGP migration

### DIFF
--- a/.pi/todos/49cbbc17.md
+++ b/.pi/todos/49cbbc17.md
@@ -10,7 +10,7 @@
     "envoy",
     "reliability"
   ],
-  "status": "open",
+  "status": "closed",
   "created_at": "2026-05-09T02:42:50.924Z"
 }
 
@@ -126,3 +126,41 @@ Results:
 - Sample internal DNS via UCG resolves `hass`, `go2rtc`, `grafana`, and `prometheus` hostnames to `10.0.88.200`.
 
 Status: healthy. Continue the 24–48h observation window. Do not expand BGP beyond Envoy yet. Earliest 24h review point is `2026-05-10 15:34 AEST`; 48h point is `2026-05-11 15:34 AEST`.
+
+### 2026-05-11 — 48h+ observation check healthy
+
+Observation check at `2026-05-11 22:19 AEST`, about 54h45m after the `2026-05-09 15:34 AEST` observation window started.
+
+Results:
+
+- Cluster nodes: `5/5 Ready`; no non-running pods found in the basic `kubectl get pods -A --field-selector=status.phase!=Running` check, excluding completed jobs.
+- Flux reports no not-ready Kustomizations or HelmReleases via `--status-selector ready=false`.
+- Envoy Services still use the routed BGP VIPs with `externalTrafficPolicy: Local`:
+  - `network/envoy-internal` → `10.0.88.200`
+  - `network/envoy-external` → `10.0.88.201`
+- Gateway `Accepted` and `Programmed` conditions are `True` for both Envoy Gateways; Gateway status reports `5/5` Envoy replicas available.
+- Envoy L2 leases remain absent; the Cilium L2 policy still excludes `envoy-internal` and `envoy-external` by Gateway service label.
+- Non-Envoy Cilium L2 remains active for the other `12` LoadBalancer Services; all current non-Envoy LoadBalancer Services use `externalTrafficPolicy: Cluster`.
+- Ready Envoy EndpointSlice endpoints exist on all five Kubernetes nodes for both `envoy-internal` and `envoy-external`.
+- Envoy pods are `10/10` containers ready across five nodes for each Gateway, with `0` restarts.
+- Cilium pods are ready on all five nodes with `0` restarts.
+- Cilium BGP node config status is `established` to UCG (`10.0.87.1`, AS `64513`) on all five nodes, each advertising exactly `2` IPv4 unicast routes.
+- Prometheus blackbox `probe_success{probe="envoy-vip"}` is `1` for all four sockets, including `min_over_time(...[5m])`:
+  - `10.0.88.200:80`
+  - `10.0.88.200:443`
+  - `10.0.88.201:80`
+  - `10.0.88.201:443`
+- `cilium_bgp_control_plane_advertised_routes` reports `2` for each Cilium pod, matching the approved Envoy-only route scope.
+- No firing Prometheus alerts matching `Envoy|Cilium|TargetDown|Endpoint|Gateway`.
+- Local TCP checks passed for all four Envoy VIP sockets.
+- UCG-origin TCP checks passed for all four Envoy VIP sockets.
+- UCG BGP sessions remain established to all five Cilium nodes, with each peer receiving `2` prefixes and uptime around `2d07h`.
+- UCG FRR running-config still has exact inbound prefix-list filtering for only:
+  - `10.0.88.200/32`
+  - `10.0.88.201/32`
+- UCG FRR still applies `neighbor K8S_CILIUM maximum-prefix 2` and inbound route-map `K8S_CILIUM_IN`.
+- UCG BGP and kernel routes install only the two Envoy `/32` VIPs from this migration; no old `10.0.80.200/201`, pod CIDR (`10.69.0.0/16`), or service CIDR (`10.96.0.0/16`) routes were observed.
+- Sample internal DNS via UCG resolves `hass`, `go2rtc`, `grafana`, and `prometheus` hostnames to `10.0.88.200`.
+- Sample HTTPS route checks through the internal Envoy VIP reached backends successfully (`go2rtc` `200`, `grafana` `302`, and `HEAD` reaching `hass`/`prometheus` with backend `405`).
+
+Status: healthy after the full 48h observation window. Keep BGP scoped to Envoy-only unless a separate follow-up explicitly expands the advertised route scope.


### PR DESCRIPTION
## Summary
- Close TODO-49cbbc17 after the 48h+ Envoy VIP BGP observation window passed healthy.
- Record the 2026-05-11 final validation results for Envoy VIPs, Cilium BGP, UCG route filtering, probes, alerts, and DNS/route samples.

## Validation
- `kubectl get nodes -o wide`
- `kubectl get svc -n network envoy-internal envoy-external -o wide`
- `kubectl get gateway -n network envoy-internal envoy-external -o wide`
- `kubectl get endpointslice -n network -l kubernetes.io/service-name=<envoy-service> -o json`
- Prometheus queries for `probe_success{probe="envoy-vip"}` and `cilium_bgp_control_plane_advertised_routes`
- UCG `vtysh` BGP summary/routes and FRR running-config checks
- Local and UCG-origin TCP checks for `10.0.88.200/201:{80,443}`
