### PR TITLE
feat(cilium): add BGP LoadBalancer canary

### DIFF
--- a/.pi/todos/c7ae6934.md
+++ b/.pi/todos/c7ae6934.md
@@ -1,0 +1,102 @@
+{
+  "id": "c7ae6934",
+  "title": "Expand routed BGP LoadBalancer prefix beyond Envoy",
+  "tags": [
+    "home-ops",
+    "network",
+    "cilium",
+    "bgp",
+    "unifi",
+    "loadbalancer",
+    "reliability"
+  ],
+  "status": "open",
+  "created_at": "2026-05-12T00:37:34.539Z",
+  "assigned_to_session": "019e16f9-7d3c-74ec-b471-3010064f116a"
+}
+
+# Expand routed BGP LoadBalancer prefix beyond Envoy
+
+## GitHub issue
+
+- https://github.com/adampetrovic/home-ops/issues/2625
+
+## Goal
+
+Expand the routed Kubernetes LoadBalancer BGP pattern beyond Envoy while keeping the migration opt-in, observable, and safely rollbackable.
+
+## Starting point
+
+- Dedicated routed LB prefix exists: `10.0.88.0/24`.
+- Envoy is already BGP-only:
+  - `network/envoy-internal` → `10.0.88.200/32`
+  - `network/envoy-external` → `10.0.88.201/32`
+- UCG exact inbound prefix-list filtering and `maximum-prefix 2` are active for Envoy only.
+- Cilium L2 remains active for non-Envoy LoadBalancer Services.
+- Current non-Envoy LoadBalancer Services use `externalTrafficPolicy: Cluster`.
+
+## Proposed next phase
+
+1. Add an opt-in Service label, e.g. `lb-transport=bgp`.
+2. Add a second CiliumBGPAdvertisement selecting labelled Services.
+3. Update Cilium L2 policy to exclude labelled BGP Services.
+4. Add a harmless BGP canary LoadBalancer Service on `network/echo-server`, e.g. `10.0.88.10:8080`.
+5. Update UCG exact prefix-list and `maximum-prefix` deliberately for the canary.
+6. Add blackbox probe + alert for the canary.
+7. Observe 24h, then migrate remaining LoadBalancers in small waves.
+
+## Guardrails
+
+- Do not advertise the whole `10.0.88.0/24` to the UCG yet.
+- Keep UCG inbound route filtering exact `/32`s per wave.
+- Keep `maximum-prefix` equal to the approved number of prefixes for the current wave.
+- Do not migrate `externalTrafficPolicy: Local` Services broadly until the Cilium BGP readiness fix from cilium/cilium#45286 is available in the deployed release and failover-tested.
+- Critical home services (`home-assistant`, `mosquitto`, `adguard-dns`, `ntpd`) should be last.
+
+## Candidate waves
+
+- Canary: `network/echo-server` direct BGP canary at `10.0.88.10`.
+- Low-risk Cluster-mode services: `gdb-postgres`, `vector-aggregator`, media/admin services.
+- Medium-risk: `influxdb`, `smtp-relay`, `postgres`, `go2rtc-streams`.
+- Last: `home-assistant`, `mosquitto`, `adguard-dns`, `ntpd`.
+
+## Progress notes
+
+### 2026-05-12 — Canary phase prepared in GitOps
+
+Prepared the first expansion phase as an opt-in BGP canary. The change is intentionally designed so future migrations can label Services with `lb-transport=bgp` rather than widening BGP to the whole LoadBalancer pool.
+
+Prepared changes:
+
+- Add Cilium BGP advertisement for labelled LoadBalancer Services (`lb-transport=bgp`).
+- Exclude labelled BGP Services from the Cilium L2 announcement policy.
+- Add `network/echo-server` direct LoadBalancer canary:
+  - VIP: `10.0.88.10`
+  - port: `8080`
+  - label: `lb-transport=bgp`
+- Add blackbox TCP probe for `10.0.88.10:8080`.
+- Add `BGPCanaryProbeDown` alert.
+- Raise `CiliumBGPAdvertisedRoutesExceeded` threshold from `2` to `3` and document the approved canary `/32`.
+- Update repo copy of UCG FRR config to allow `10.0.88.10/32` and set `maximum-prefix 3`.
+
+Important rollout ordering:
+
+1. Update/upload the live UniFi/UCG BGP config first so the UCG exact prefix-list allows `10.0.88.10/32` and `maximum-prefix 3` is active.
+2. Only then merge/apply the GitOps Cilium/echo-server/monitoring changes, otherwise Cilium may advertise a third route while UCG still enforces `maximum-prefix 2`.
+3. Validate BGP, TCP reachability, probes, and alerts after Flux applies.
+
+### 2026-05-12 — Draft PR opened, waiting on live UCG update
+
+Draft PR prepared:
+
+- https://github.com/adampetrovic/home-ops/pull/2626
+
+The PR is intentionally left as draft because live UCG FRR still has only the two Envoy prefixes and `maximum-prefix 2`:
+
+```text
+ip prefix-list K8S_CILIUM_VIPS seq 10 permit 10.0.88.200/32
+ip prefix-list K8S_CILIUM_VIPS seq 20 permit 10.0.88.201/32
+neighbor K8S_CILIUM maximum-prefix 2
+```
+
+Before making PR #2626 ready/mergeable, update/upload the UCG BGP config to add `10.0.88.10/32` and raise `maximum-prefix` to `3`.

--- a/kubernetes/apps/kube-system/cilium/app/bgp.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/bgp.yaml
@@ -52,3 +52,19 @@ spec:
             values:
               - envoy-internal
               - envoy-external
+---
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
+metadata:
+  name: labelled-loadbalancers
+  labels:
+    advertise: bgp-envoy
+spec:
+  advertisements:
+    - advertisementType: Service
+      service:
+        addresses:
+          - LoadBalancerIP
+      selector:
+        matchLabels:
+          lb-transport: bgp

--- a/kubernetes/apps/kube-system/cilium/app/network.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/network.yaml
@@ -13,6 +13,10 @@ spec:
         values:
           - envoy-internal
           - envoy-external
+      - key: lb-transport
+        operator: NotIn
+        values:
+          - bgp
   interfaces:
     - bond0
   nodeSelector:

--- a/kubernetes/apps/kube-system/cilium/ucg-cilium-bgp.conf
+++ b/kubernetes/apps/kube-system/cilium/ucg-cilium-bgp.conf
@@ -17,7 +17,7 @@ router bgp 64513
   neighbor K8S_CILIUM soft-reconfiguration inbound
   neighbor K8S_CILIUM route-map K8S_CILIUM_IN in
   neighbor K8S_CILIUM route-map K8S_CILIUM_OUT out
-  neighbor K8S_CILIUM maximum-prefix 2
+  neighbor K8S_CILIUM maximum-prefix 3
   maximum-paths 5
  exit-address-family
 exit
@@ -34,3 +34,4 @@ exit
 
 ip prefix-list K8S_CILIUM_VIPS seq 10 permit 10.0.88.200/32
 ip prefix-list K8S_CILIUM_VIPS seq 20 permit 10.0.88.201/32
+ip prefix-list K8S_CILIUM_VIPS seq 30 permit 10.0.88.10/32

--- a/kubernetes/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo-server/app/helmrelease.yaml
@@ -66,7 +66,20 @@ spec:
             runAsNonRoot: true
     service:
       app:
+        forceRename: echo-server
+        primary: true
         controller: echo-server
+        ports:
+          http:
+            port: *port
+      bgp-canary:
+        controller: echo-server
+        type: LoadBalancer
+        labels:
+          lb-transport: bgp
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: echo-bgp-canary.${SECRET_DOMAIN}
+          io.cilium/lb-ipam-ips: 10.0.88.10
         ports:
           http:
             port: *port
@@ -87,9 +100,17 @@ spec:
         parentRefs:
           - name: envoy-external
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
       internal:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http

--- a/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
@@ -77,3 +77,32 @@ spec:
     - action: replace
       targetLabel: __address__
       replacement: blackbox-exporter.observability.svc.cluster.local:9115
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: bgp-canary-tcp-probe
+spec:
+  scrapeInterval: 30s
+  metricsPath: /probe
+  params:
+    module: ["tcp_connect"]
+  staticConfigs:
+    - targets:
+        - "10.0.88.10:8080"
+      labels:
+        probe: bgp-canary
+        service: echo-server
+        vip: "10.0.88.10"
+        port: "8080"
+  relabelings:
+    - action: replace
+      sourceLabels: [__address__]
+      targetLabel: __param_target
+    - action: replace
+      sourceLabels: [__param_target]
+      targetLabel: instance
+    - action: replace
+      targetLabel: __address__
+      replacement: blackbox-exporter.observability.svc.cluster.local:9115

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/envoy-bgp-rules.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/envoy-bgp-rules.yaml
@@ -26,16 +26,32 @@ spec:
           labels:
             severity: critical
 
+        - alert: BGPCanaryProbeDown
+          annotations:
+            summary: "BGP canary VIP probe failing for {{ $labels.instance }}"
+            description: |
+              Blackbox TCP probing cannot connect to BGP canary VIP {{ $labels.vip }} port {{ $labels.port }}.
+
+              Check UCG BGP routes and echo-server endpoints:
+                ssh root@10.0.0.1 'vtysh -c "show bgp ipv4 unicast summary" -c "show ip route bgp"'
+                kubectl get svc -n network echo-server-bgp-canary -o wide
+                kubectl get endpointslice -n network -l kubernetes.io/service-name=echo-server-bgp-canary -o wide
+          expr: min_over_time(probe_success{probe="bgp-canary"}[2m]) == 0
+          for: 1m
+          labels:
+            severity: critical
+
         - alert: CiliumBGPAdvertisedRoutesExceeded
           annotations:
-            summary: "Cilium BGP pod {{ $labels.pod }} is advertising more than the two approved Envoy VIP routes"
+            summary: "Cilium BGP pod {{ $labels.pod }} is advertising more than the three approved BGP LoadBalancer routes"
             description: |
-              Cilium BGP should only advertise the two Envoy LoadBalancer VIPs during this phase:
+              Cilium BGP should only advertise the approved Envoy and canary LoadBalancer VIPs during this phase:
                 - 10.0.88.200/32
                 - 10.0.88.201/32
+                - 10.0.88.10/32
 
               This pod reports {{ $value }} advertised routes. The UCG inbound prefix-list should reject unexpected prefixes, but Cilium advertisement scope may have drifted and should be investigated before expanding BGP further.
-          expr: cilium_bgp_control_plane_advertised_routes > 2
+          expr: cilium_bgp_control_plane_advertised_routes > 3
           for: 2m
           labels:
             severity: critical


### PR DESCRIPTION
## Summary
- Add opt-in Cilium BGP advertisement for Services labelled `lb-transport=bgp`.
- Exclude labelled BGP Services from the Cilium L2 announcement policy.
- Add a direct BGP LoadBalancer canary on `network/echo-server` at `10.0.88.10:8080`.
- Add blackbox probing and alerting for the canary.
- Update the repo copy of the UCG FRR config to allow `10.0.88.10/32` and raise `maximum-prefix` to `3`.
- Create/claim TODO-c7ae6934 for the broader BGP expansion phase.

## Rollout order — do not merge before UCG is updated
1. Upload/apply the UCG BGP config first so live FRR has:
   - `ip prefix-list K8S_CILIUM_VIPS ... permit 10.0.88.10/32`
   - `neighbor K8S_CILIUM maximum-prefix 3`
2. Then merge this PR so Flux creates the canary Service and Cilium advertises the third `/32`.
3. Validate UCG BGP routes, TCP reachability, blackbox probes, and alerts.

Merging this before the live UCG config is updated may make Cilium advertise a third route while the UCG is still enforcing `maximum-prefix 2`.

## Validation
- `kustomize build kubernetes/apps/kube-system/cilium/app`
- `kustomize build kubernetes/apps/network/echo-server/app`
- `kustomize build kubernetes/apps/observability/blackbox-exporter/app`
- `kustomize build kubernetes/apps/observability/kube-prometheus-stack/app`
- `helm template echo-server oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.0 -n network -f /tmp/echo-values.yaml`
