### PR TITLE
docs(todo): record BGP canary rollout

### DIFF
--- a/.pi/todos/c7ae6934.md
+++ b/.pi/todos/c7ae6934.md
@@ -100,3 +100,52 @@ neighbor K8S_CILIUM maximum-prefix 2
 ```
 
 Before making PR #2626 ready/mergeable, update/upload the UCG BGP config to add `10.0.88.10/32` and raise `maximum-prefix` to `3`.
+
+### 2026-05-12 — Canary merged and initial rollout healthy
+
+UCG upload was completed first, then live UCG FRR was verified before merging PR #2626.
+
+Live UCG pre-merge checks:
+
+- Exact inbound prefix-list contains only the approved three `/32` VIPs:
+  - `10.0.88.200/32`
+  - `10.0.88.201/32`
+  - `10.0.88.10/32`
+- `neighbor K8S_CILIUM maximum-prefix 3` is active.
+- Inbound route-map `K8S_CILIUM_IN` still matches `K8S_CILIUM_VIPS` and has a deny fallback.
+- BGP sessions re-established to all five Cilium nodes after the UCG BGP reload.
+
+Merged PR:
+
+- https://github.com/adampetrovic/home-ops/pull/2626
+- Merge commit on `main`: `2039bec3`
+
+Post-merge validation:
+
+- Flux applied `refs/heads/main@sha1:2039bec3` for `kube-system/cilium`, `network/echo-server`, `observability/blackbox-exporter`, and `observability/kube-prometheus-stack`.
+- No not-ready Flux Kustomizations or HelmReleases remained after reconciliation.
+- Canary Service is present:
+  - `network/echo-server-bgp-canary`
+  - `LoadBalancer` VIP: `10.0.88.10`
+  - port: `8080/TCP`
+  - label: `lb-transport=bgp`
+- `CiliumBGPAdvertisement/labelled-loadbalancers` is present.
+- Cilium L2 policy excludes labelled BGP Services via `lb-transport NotIn [bgp]`.
+- No Cilium L2 lease exists for `network/echo-server-bgp-canary`.
+- Ready EndpointSlice exists for the canary Service.
+- Cilium BGP node status reports `established` for all five nodes, each advertising exactly `3` IPv4 unicast routes.
+- UCG receives `3` prefixes from each node.
+- UCG installs ECMP BGP routes for exactly the three approved VIPs:
+  - `10.0.88.10/32`
+  - `10.0.88.200/32`
+  - `10.0.88.201/32`
+- Local TCP check to `10.0.88.10:8080` passed.
+- UCG-origin TCP check to `10.0.88.10:8080` passed.
+- Prometheus blackbox probes are healthy:
+  - `probe_success{probe="bgp-canary"}` is `1` for `10.0.88.10:8080`.
+  - Envoy VIP probes remain `1` for all four existing sockets.
+  - `min_over_time(...[2m])` is also `1` for the canary and Envoy VIP sockets.
+- `cilium_bgp_control_plane_advertised_routes` reports `3` for each Cilium pod.
+- No firing Prometheus alerts matching `BGP|Envoy|Cilium|TargetDown|Endpoint|Gateway`.
+
+Status: initial canary rollout healthy. Begin 24h observation before migrating additional LoadBalancer Services.


### PR DESCRIPTION
## Summary
- Record the BGP canary rollout validation after PR #2626 merged.
- Document UCG route filtering, Cilium route counts, canary reachability, Prometheus probes, and alert status.

## Validation
- Live UCG FRR prefix-list/maximum-prefix checks.
- Flux reconciliation checks for Cilium, echo-server, blackbox-exporter, and kube-prometheus-stack.
- Kubernetes Service/EndpointSlice checks for the canary.
- Cilium BGP node config route count checks.
- Local and UCG-origin TCP checks for `10.0.88.10:8080`.
- Prometheus queries for `probe_success`, `cilium_bgp_control_plane_advertised_routes`, and relevant firing alerts.
