### PR TITLE
feat(cilium): migrate low-risk LoadBalancers to BGP

### DIFF
--- a/.pi/todos/c7ae6934.md
+++ b/.pi/todos/c7ae6934.md
@@ -149,3 +149,46 @@ Post-merge validation:
 - No firing Prometheus alerts matching `BGP|Envoy|Cilium|TargetDown|Endpoint|Gateway`.
 
 Status: initial canary rollout healthy. Begin 24h observation before migrating additional LoadBalancer Services.
+
+### 2026-05-12 — Wave 1 prepared, observation skipped by operator
+
+Adam explicitly chose to skip the 24h canary observation and proceed because the canary is healthy now.
+
+Prepared Wave 1 for two low-risk, non-critical Cluster-mode LoadBalancer Services:
+
+- `observability/vector-aggregator`
+  - old VIP: `10.0.81.8`
+  - new routed BGP VIP: `10.0.88.8`
+  - opt-in label: `lb-transport=bgp`
+  - TCP probes: `8686`, `6000`, `6010`
+- `gdb/gdb-postgres`
+  - old VIP: `10.0.81.15`
+  - new routed BGP VIP: `10.0.88.15`
+  - opt-in label: `lb-transport=bgp`
+  - TCP probe: `5432`
+
+Prepared supporting changes:
+
+- UCG FRR repo config raises `maximum-prefix` from `3` to `5`.
+- UCG exact inbound prefix-list adds:
+  - `10.0.88.8/32`
+  - `10.0.88.15/32`
+- Added `bgp-loadbalancer-tcp-probe` ScrapeConfig.
+- Added `BGPLoadBalancerProbeDown` alert.
+- Raised `CiliumBGPAdvertisedRoutesExceeded` threshold from `3` to `5` and documented the approved `/32`s.
+
+Validation before rollout:
+
+- `kustomize build` passed for:
+  - `kubernetes/apps/gdb/gdb/database`
+  - `kubernetes/apps/observability/vector/app/aggregator`
+  - `kubernetes/apps/observability/blackbox-exporter/app`
+  - `kubernetes/apps/observability/kube-prometheus-stack/app`
+- Helm rendering of `vector-aggregator` with app-template `5.0.0` confirms the Service remains `LoadBalancer`, has `lb-transport=bgp`, and uses `10.0.88.8`.
+- Kustomize rendering of `gdb-postgres` confirms the Service remains `LoadBalancer`, has `lb-transport=bgp`, and uses `10.0.88.15`.
+
+Important rollout ordering remains the same:
+
+1. Upload/apply the UCG config first so live FRR allows five prefixes and the two new `/32`s.
+2. Then merge/apply the GitOps changes.
+3. Validate route count, exact routes, L2 lease absence for labelled Services, TCP probes, and alerts.

--- a/kubernetes/apps/gdb/gdb/database/service.yaml
+++ b/kubernetes/apps/gdb/gdb/database/service.yaml
@@ -3,9 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gdb-postgres
+  labels:
+    lb-transport: bgp
   annotations:
     external-dns.alpha.kubernetes.io/hostname: gdb-postgres.${SECRET_DOMAIN}
-    io.cilium/lb-ipam-ips: 10.0.81.15
+    io.cilium/lb-ipam-ips: 10.0.88.15
 spec:
   type: LoadBalancer
   ports:

--- a/kubernetes/apps/kube-system/cilium/ucg-cilium-bgp.conf
+++ b/kubernetes/apps/kube-system/cilium/ucg-cilium-bgp.conf
@@ -17,7 +17,7 @@ router bgp 64513
   neighbor K8S_CILIUM soft-reconfiguration inbound
   neighbor K8S_CILIUM route-map K8S_CILIUM_IN in
   neighbor K8S_CILIUM route-map K8S_CILIUM_OUT out
-  neighbor K8S_CILIUM maximum-prefix 3
+  neighbor K8S_CILIUM maximum-prefix 5
   maximum-paths 5
  exit-address-family
 exit
@@ -35,3 +35,5 @@ exit
 ip prefix-list K8S_CILIUM_VIPS seq 10 permit 10.0.88.200/32
 ip prefix-list K8S_CILIUM_VIPS seq 20 permit 10.0.88.201/32
 ip prefix-list K8S_CILIUM_VIPS seq 30 permit 10.0.88.10/32
+ip prefix-list K8S_CILIUM_VIPS seq 40 permit 10.0.88.8/32
+ip prefix-list K8S_CILIUM_VIPS seq 50 permit 10.0.88.15/32

--- a/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
@@ -106,3 +106,53 @@ spec:
     - action: replace
       targetLabel: __address__
       replacement: blackbox-exporter.observability.svc.cluster.local:9115
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: bgp-loadbalancer-tcp-probe
+spec:
+  scrapeInterval: 30s
+  metricsPath: /probe
+  params:
+    module: ["tcp_connect"]
+  staticConfigs:
+    - targets:
+        - "10.0.88.8:8686"
+      labels:
+        probe: bgp-loadbalancer
+        service: vector-aggregator
+        vip: "10.0.88.8"
+        port: "8686"
+    - targets:
+        - "10.0.88.8:6000"
+      labels:
+        probe: bgp-loadbalancer
+        service: vector-aggregator
+        vip: "10.0.88.8"
+        port: "6000"
+    - targets:
+        - "10.0.88.8:6010"
+      labels:
+        probe: bgp-loadbalancer
+        service: vector-aggregator
+        vip: "10.0.88.8"
+        port: "6010"
+    - targets:
+        - "10.0.88.15:5432"
+      labels:
+        probe: bgp-loadbalancer
+        service: gdb-postgres
+        vip: "10.0.88.15"
+        port: "5432"
+  relabelings:
+    - action: replace
+      sourceLabels: [__address__]
+      targetLabel: __param_target
+    - action: replace
+      sourceLabels: [__param_target]
+      targetLabel: instance
+    - action: replace
+      targetLabel: __address__
+      replacement: blackbox-exporter.observability.svc.cluster.local:9115

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/envoy-bgp-rules.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/envoy-bgp-rules.yaml
@@ -41,17 +41,34 @@ spec:
           labels:
             severity: critical
 
+        - alert: BGPLoadBalancerProbeDown
+          annotations:
+            summary: "BGP LoadBalancer VIP probe failing for {{ $labels.service }} at {{ $labels.instance }}"
+            description: |
+              Blackbox TCP probing cannot connect to BGP LoadBalancer VIP {{ $labels.vip }} port {{ $labels.port }}.
+
+              Check UCG BGP routes and the affected Service endpoints:
+                ssh root@10.0.0.1 'vtysh -c "show bgp ipv4 unicast summary" -c "show ip route bgp"'
+                kubectl get svc -A -l lb-transport=bgp -o wide
+                kubectl get endpointslice -A -l kubernetes.io/service-name={{ $labels.service }} -o wide
+          expr: min_over_time(probe_success{probe="bgp-loadbalancer"}[2m]) == 0
+          for: 1m
+          labels:
+            severity: critical
+
         - alert: CiliumBGPAdvertisedRoutesExceeded
           annotations:
-            summary: "Cilium BGP pod {{ $labels.pod }} is advertising more than the three approved BGP LoadBalancer routes"
+            summary: "Cilium BGP pod {{ $labels.pod }} is advertising more than the five approved BGP LoadBalancer routes"
             description: |
-              Cilium BGP should only advertise the approved Envoy and canary LoadBalancer VIPs during this phase:
+              Cilium BGP should only advertise the approved LoadBalancer VIPs during this phase:
                 - 10.0.88.200/32
                 - 10.0.88.201/32
                 - 10.0.88.10/32
+                - 10.0.88.8/32
+                - 10.0.88.15/32
 
               This pod reports {{ $value }} advertised routes. The UCG inbound prefix-list should reject unexpected prefixes, but Cilium advertisement scope may have drifted and should be investigated before expanding BGP further.
-          expr: cilium_bgp_control_plane_advertised_routes > 3
+          expr: cilium_bgp_control_plane_advertised_routes > 5
           for: 2m
           labels:
             severity: critical

--- a/kubernetes/apps/observability/vector/app/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/app/aggregator/helmrelease.yaml
@@ -42,9 +42,11 @@ spec:
       app:
         type: LoadBalancer
         controller: vector-aggregator
+        labels:
+          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: vector.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.81.8
+          io.cilium/lb-ipam-ips: 10.0.88.8
         ports:
           http:
             port: 8686


### PR DESCRIPTION
## Summary
- Move Wave 1 low-risk LoadBalancer Services to the routed BGP prefix:
  - `observability/vector-aggregator` -> `10.0.88.8`
  - `gdb/gdb-postgres` -> `10.0.88.15`
- Add `lb-transport=bgp` to both Services so Cilium advertises them via the opt-in BGP selector and excludes them from L2 announcements.
- Add blackbox TCP probes and `BGPLoadBalancerProbeDown` alerting for the new VIP sockets.
- Raise approved Cilium BGP route count from 3 to 5.
- Update the repo copy of the UCG FRR config with the two new exact `/32`s and `maximum-prefix 5`.
- Record Wave 1 prep in TODO-c7ae6934.

## Rollout order — do not merge before UCG is updated
1. Upload/apply the UCG BGP config first so live FRR has:
   - `ip prefix-list K8S_CILIUM_VIPS ... permit 10.0.88.8/32`
   - `ip prefix-list K8S_CILIUM_VIPS ... permit 10.0.88.15/32`
   - `neighbor K8S_CILIUM maximum-prefix 5`
2. Then merge this PR so Flux moves the two Services and Cilium advertises the two additional `/32`s.
3. Validate UCG BGP routes, old/new VIP reachability, blackbox probes, and alerts.

Merging before the live UCG config is updated may make Cilium advertise five routes while the UCG is still enforcing `maximum-prefix 3`.

## Validation
- `kustomize build kubernetes/apps/gdb/gdb/database`
- `kustomize build kubernetes/apps/observability/vector/app/aggregator`
- `kustomize build kubernetes/apps/observability/blackbox-exporter/app`
- `kustomize build kubernetes/apps/observability/kube-prometheus-stack/app`
- `helm template vector-aggregator oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.0 -n observability -f /tmp/vector-values.yaml`
