### PR TITLE
docs(todo): record BGP Wave 1 rollout

### DIFF
--- a/.pi/todos/c7ae6934.md
+++ b/.pi/todos/c7ae6934.md
@@ -192,3 +192,61 @@ Important rollout ordering remains the same:
 1. Upload/apply the UCG config first so live FRR allows five prefixes and the two new `/32`s.
 2. Then merge/apply the GitOps changes.
 3. Validate route count, exact routes, L2 lease absence for labelled Services, TCP probes, and alerts.
+
+### 2026-05-12 — Wave 1 merged and rollout healthy
+
+UCG upload was completed first, then live UCG FRR was verified before merging PR #2630.
+
+Live UCG pre-merge checks:
+
+- Exact inbound prefix-list contains only the approved five `/32` VIPs:
+  - `10.0.88.200/32`
+  - `10.0.88.201/32`
+  - `10.0.88.10/32`
+  - `10.0.88.8/32`
+  - `10.0.88.15/32`
+- `neighbor K8S_CILIUM maximum-prefix 5` is active.
+- Inbound route-map `K8S_CILIUM_IN` still matches `K8S_CILIUM_VIPS` and has a deny fallback.
+- BGP sessions re-established to all five Cilium nodes after the UCG BGP reload.
+
+Merged PR:
+
+- https://github.com/adampetrovic/home-ops/pull/2630
+- Merge commit on `main`: `8246d7f3`
+
+Post-merge validation:
+
+- Flux applied `refs/heads/main@sha1:8246d7f3` for `gdb-postgres-cluster`, `observability/vector`, `observability/blackbox-exporter`, and `observability/kube-prometheus-stack`.
+- No not-ready Flux Kustomizations or HelmReleases remained after reconciliation.
+- BGP-labelled Services now present:
+  - `network/echo-server-bgp-canary` → `10.0.88.10`, `8080/TCP`
+  - `observability/vector-aggregator` → `10.0.88.8`, `8686/TCP`, `6000/TCP`, `6010/TCP`, `6020/UDP`
+  - `gdb/gdb-postgres` → `10.0.88.15`, `5432/TCP`
+- Old VIPs `10.0.81.8` and `10.0.81.15` are no longer assigned to any LoadBalancer Service.
+- No Cilium L2 leases exist for the three BGP-labelled Services.
+- Ready EndpointSlices exist for the migrated Services.
+- Cilium BGP node status reports `established` for all five nodes, each advertising exactly `5` IPv4 unicast routes.
+- UCG receives `5` prefixes from each node.
+- UCG installs ECMP BGP routes for exactly the five approved VIPs:
+  - `10.0.88.8/32`
+  - `10.0.88.10/32`
+  - `10.0.88.15/32`
+  - `10.0.88.200/32`
+  - `10.0.88.201/32`
+- UCG route checks did not show old Envoy VIPs, pod CIDR, or service CIDR routes.
+- Local and UCG-origin TCP checks passed for:
+  - `10.0.88.8:8686`
+  - `10.0.88.8:6000`
+  - `10.0.88.8:6010`
+  - `10.0.88.15:5432`
+  - `10.0.88.10:8080`
+  - Envoy VIP sockets `10.0.88.200/201:{80,443}`
+- Prometheus blackbox probes are healthy:
+  - `probe_success{probe="bgp-loadbalancer"}` is `1` for the Wave 1 TCP sockets.
+  - `probe_success{probe="bgp-canary"}` remains `1` for `10.0.88.10:8080`.
+  - Envoy VIP probes remain `1` for all four existing sockets.
+  - `min_over_time(...[2m])` is also `1` for all BGP-related probe targets.
+- `cilium_bgp_control_plane_advertised_routes` reports `5` for each Cilium pod.
+- No firing Prometheus alerts matching `BGP|Envoy|Cilium|TargetDown|Endpoint|Gateway`.
+
+Status: Wave 1 rollout healthy. Continue with small waves; keep exact UCG `/32` filtering and `maximum-prefix` aligned before each GitOps merge.


### PR DESCRIPTION
## Summary
- Record Wave 1 BGP LoadBalancer rollout validation after PR #2630 merged.
- Document UCG prefix filtering, Cilium route counts, migrated Service VIPs, L2 lease removal, TCP checks, probes, and alerts.

## Validation
- Live UCG FRR prefix-list/maximum-prefix checks.
- Flux reconciliation checks for gdb, vector, blackbox-exporter, and kube-prometheus-stack.
- Kubernetes Service/EndpointSlice checks for BGP-labelled Services.
- Cilium BGP node config route count checks.
- Local and UCG-origin TCP checks for new BGP VIP sockets.
- Prometheus queries for `probe_success`, `cilium_bgp_control_plane_advertised_routes`, and relevant firing alerts.
