### PR TITLE
feat(cilium): migrate medium-risk LoadBalancers to BGP

### DIFF
--- a/.pi/todos/c7ae6934.md
+++ b/.pi/todos/c7ae6934.md
@@ -250,3 +250,51 @@ Post-merge validation:
 - No firing Prometheus alerts matching `BGP|Envoy|Cilium|TargetDown|Endpoint|Gateway`.
 
 Status: Wave 1 rollout healthy. Continue with small waves; keep exact UCG `/32` filtering and `maximum-prefix` aligned before each GitOps merge.
+
+### 2026-05-12 — Wave 2 prepared
+
+Prepared Wave 2 for three medium-risk Cluster-mode LoadBalancer Services:
+
+- `network/smtp-relay`
+  - old VIP: `10.0.81.6`
+  - new routed BGP VIP: `10.0.88.6`
+  - opt-in label: `lb-transport=bgp`
+  - TCP probes: `25`, `9749`
+- `observability/influxdb`
+  - old VIP: `10.0.81.9`
+  - new routed BGP VIP: `10.0.88.9`
+  - opt-in label: `lb-transport=bgp`
+  - TCP probe: `8086`
+- `database/postgres`
+  - old VIP: `10.0.81.12`
+  - new routed BGP VIP: `10.0.88.12`
+  - opt-in label: `lb-transport=bgp`
+  - TCP probe: `5432`
+
+Prepared supporting changes:
+
+- UCG FRR repo config raises `maximum-prefix` from `5` to `8`.
+- UCG exact inbound prefix-list adds:
+  - `10.0.88.6/32`
+  - `10.0.88.9/32`
+  - `10.0.88.12/32`
+- Added the new Wave 2 sockets to the existing `bgp-loadbalancer-tcp-probe` ScrapeConfig.
+- Raised `CiliumBGPAdvertisedRoutesExceeded` threshold from `5` to `8` and documented the approved `/32`s.
+
+Validation before rollout:
+
+- `kustomize build` passed for:
+  - `kubernetes/apps/database/cloudnative-pg/cluster`
+  - `kubernetes/apps/network/smtp-relay/app`
+  - `kubernetes/apps/observability/influxdb/app`
+  - `kubernetes/apps/observability/blackbox-exporter/app`
+  - `kubernetes/apps/observability/kube-prometheus-stack/app`
+- Helm rendering of `smtp-relay` with app-template `5.0.0` confirms the Service remains `LoadBalancer`, has `lb-transport=bgp`, and uses `10.0.88.6`.
+- Helm rendering of `influxdb` with app-template `5.0.0` confirms the Service remains `LoadBalancer`, has `lb-transport=bgp`, and uses `10.0.88.9`.
+- Kustomize rendering of `postgres` confirms the Service remains `LoadBalancer`, has `lb-transport=bgp`, and uses `10.0.88.12`.
+
+Important rollout ordering remains the same:
+
+1. Upload/apply the UCG config first so live FRR allows eight prefixes and the three new `/32`s.
+2. Then merge/apply the GitOps changes.
+3. Validate route count, exact routes, L2 lease absence for labelled Services, TCP probes, and alerts.

--- a/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
@@ -3,9 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgres
+  labels:
+    lb-transport: bgp
   annotations:
     external-dns.alpha.kubernetes.io/hostname: postgres.${SECRET_DOMAIN}
-    io.cilium/lb-ipam-ips: 10.0.81.12
+    io.cilium/lb-ipam-ips: 10.0.88.12
 spec:
   type: LoadBalancer
   ports:

--- a/kubernetes/apps/kube-system/cilium/ucg-cilium-bgp.conf
+++ b/kubernetes/apps/kube-system/cilium/ucg-cilium-bgp.conf
@@ -17,7 +17,7 @@ router bgp 64513
   neighbor K8S_CILIUM soft-reconfiguration inbound
   neighbor K8S_CILIUM route-map K8S_CILIUM_IN in
   neighbor K8S_CILIUM route-map K8S_CILIUM_OUT out
-  neighbor K8S_CILIUM maximum-prefix 5
+  neighbor K8S_CILIUM maximum-prefix 8
   maximum-paths 5
  exit-address-family
 exit
@@ -37,3 +37,6 @@ ip prefix-list K8S_CILIUM_VIPS seq 20 permit 10.0.88.201/32
 ip prefix-list K8S_CILIUM_VIPS seq 30 permit 10.0.88.10/32
 ip prefix-list K8S_CILIUM_VIPS seq 40 permit 10.0.88.8/32
 ip prefix-list K8S_CILIUM_VIPS seq 50 permit 10.0.88.15/32
+ip prefix-list K8S_CILIUM_VIPS seq 60 permit 10.0.88.6/32
+ip prefix-list K8S_CILIUM_VIPS seq 70 permit 10.0.88.9/32
+ip prefix-list K8S_CILIUM_VIPS seq 80 permit 10.0.88.12/32

--- a/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
@@ -53,9 +53,11 @@ spec:
       app:
         type: LoadBalancer
         controller: smtp-relay
+        labels:
+          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: smtp.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.81.6
+          io.cilium/lb-ipam-ips: 10.0.88.6
         ports:
           http:
             port: 25

--- a/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
@@ -146,6 +146,34 @@ spec:
         service: gdb-postgres
         vip: "10.0.88.15"
         port: "5432"
+    - targets:
+        - "10.0.88.6:25"
+      labels:
+        probe: bgp-loadbalancer
+        service: smtp-relay
+        vip: "10.0.88.6"
+        port: "25"
+    - targets:
+        - "10.0.88.6:9749"
+      labels:
+        probe: bgp-loadbalancer
+        service: smtp-relay
+        vip: "10.0.88.6"
+        port: "9749"
+    - targets:
+        - "10.0.88.9:8086"
+      labels:
+        probe: bgp-loadbalancer
+        service: influxdb
+        vip: "10.0.88.9"
+        port: "8086"
+    - targets:
+        - "10.0.88.12:5432"
+      labels:
+        probe: bgp-loadbalancer
+        service: postgres
+        vip: "10.0.88.12"
+        port: "5432"
   relabelings:
     - action: replace
       sourceLabels: [__address__]

--- a/kubernetes/apps/observability/influxdb/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/influxdb/app/helmrelease.yaml
@@ -56,9 +56,11 @@ spec:
       app:
         type: LoadBalancer
         controller: influxdb
+        labels:
+          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: influx-direct.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.81.9
+          io.cilium/lb-ipam-ips: 10.0.88.9
         externalTrafficPolicy: Cluster
         ports:
           http:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/envoy-bgp-rules.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/envoy-bgp-rules.yaml
@@ -58,7 +58,7 @@ spec:
 
         - alert: CiliumBGPAdvertisedRoutesExceeded
           annotations:
-            summary: "Cilium BGP pod {{ $labels.pod }} is advertising more than the five approved BGP LoadBalancer routes"
+            summary: "Cilium BGP pod {{ $labels.pod }} is advertising more than the eight approved BGP LoadBalancer routes"
             description: |
               Cilium BGP should only advertise the approved LoadBalancer VIPs during this phase:
                 - 10.0.88.200/32
@@ -66,9 +66,12 @@ spec:
                 - 10.0.88.10/32
                 - 10.0.88.8/32
                 - 10.0.88.15/32
+                - 10.0.88.6/32
+                - 10.0.88.9/32
+                - 10.0.88.12/32
 
               This pod reports {{ $value }} advertised routes. The UCG inbound prefix-list should reject unexpected prefixes, but Cilium advertisement scope may have drifted and should be investigated before expanding BGP further.
-          expr: cilium_bgp_control_plane_advertised_routes > 5
+          expr: cilium_bgp_control_plane_advertised_routes > 8
           for: 2m
           labels:
             severity: critical


### PR DESCRIPTION
## Summary
- Move Wave 2 medium-risk Cluster-mode LoadBalancer Services to the routed BGP prefix:
  - `network/smtp-relay` -> `10.0.88.6`
  - `observability/influxdb` -> `10.0.88.9`
  - `database/postgres` -> `10.0.88.12`
- Add `lb-transport=bgp` to all three Services so Cilium advertises them via the opt-in BGP selector and excludes them from L2 announcements.
- Add blackbox TCP probes for the new sockets.
- Raise approved Cilium BGP route count from 5 to 8.
- Update the repo copy of the UCG FRR config with the three new exact `/32`s and `maximum-prefix 8`.
- Record Wave 2 prep in TODO-c7ae6934.

## Rollout order — do not merge before UCG is updated
1. Upload/apply the UCG BGP config first so live FRR has:
   - `ip prefix-list K8S_CILIUM_VIPS ... permit 10.0.88.6/32`
   - `ip prefix-list K8S_CILIUM_VIPS ... permit 10.0.88.9/32`
   - `ip prefix-list K8S_CILIUM_VIPS ... permit 10.0.88.12/32`
   - `neighbor K8S_CILIUM maximum-prefix 8`
2. Then merge this PR so Flux moves the three Services and Cilium advertises the three additional `/32`s.
3. Validate UCG BGP routes, old/new VIP reachability, blackbox probes, and alerts.

Merging before the live UCG config is updated may make Cilium advertise eight routes while the UCG is still enforcing `maximum-prefix 5`.

## Validation
- `kustomize build kubernetes/apps/database/cloudnative-pg/cluster`
- `kustomize build kubernetes/apps/network/smtp-relay/app`
- `kustomize build kubernetes/apps/observability/influxdb/app`
- `kustomize build kubernetes/apps/observability/blackbox-exporter/app`
- `kustomize build kubernetes/apps/observability/kube-prometheus-stack/app`
- `helm template smtp-relay oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.0 -n network -f /tmp/smtp-values.yaml`
- `helm template influxdb oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.0 -n observability -f /tmp/influx-values.yaml`
