### PR TITLE
feat(cilium): migrate remaining LoadBalancers to BGP

### DIFF
--- a/.pi/todos/c7ae6934.md
+++ b/.pi/todos/c7ae6934.md
@@ -364,3 +364,82 @@ Post-merge validation:
 - No firing Prometheus alerts matching `BGP|Envoy|Cilium|TargetDown|Endpoint|Gateway`.
 
 Status: Wave 2 rollout healthy. Remaining L2-backed LoadBalancers are now mostly user/house-critical or special-protocol services; proceed carefully with exact UCG `/32` filtering and `maximum-prefix` aligned before each GitOps merge.
+
+### 2026-05-12 — Final wave prepared with routed-subnet UCG filter
+
+Adam requested fast-forwarding the remaining LoadBalancer Services by changing the UCG inbound filter from exact per-VIP `/32`s to the routed LoadBalancer host-route subnet, and removing `maximum-prefix`.
+
+Prepared UCG FRR config change:
+
+- Removed `neighbor K8S_CILIUM maximum-prefix 8`.
+- Replaced exact per-VIP prefix-list entries with a host-route-only subnet allow-list:
+  - `ip prefix-list K8S_CILIUM_VIPS seq 10 permit 10.0.88.0/24 ge 32 le 32`
+
+This still rejects pod CIDR, service CIDR, and non-`10.0.88.0/24` routes, but no longer caps the number of accepted BGP VIP routes inside `10.0.88.0/24`.
+
+Prepared final wave for all remaining L2-backed LoadBalancer Services:
+
+- `automation/mosquitto`
+  - old VIP: `10.0.81.1`
+  - new routed BGP VIP: `10.0.88.1`
+  - opt-in label: `lb-transport=bgp`
+  - TCP probe: `1883`
+- `media/plex`
+  - old VIP: `10.0.81.3`
+  - new routed BGP VIP: `10.0.88.3`
+  - opt-in label: `lb-transport=bgp`
+  - TCP probe: `32400`
+- `automation/home-assistant`
+  - old VIP: `10.0.81.4`
+  - new routed BGP VIP: `10.0.88.4`
+  - opt-in label: `lb-transport=bgp`
+  - TCP probes: `8123`, `21065`
+- `network/ntpd`
+  - old VIP: `10.0.81.5`
+  - new routed BGP VIP: `10.0.88.5`
+  - opt-in label: `lb-transport=bgp`
+  - UDP service: `123`
+  - no blackbox TCP probe; validate with UDP checks where possible
+- `media/qbittorrent`
+  - old VIP: `10.0.81.7`
+  - new routed BGP VIP: `10.0.88.7`
+  - opt-in label: `lb-transport=bgp`
+  - TCP probes: `50413`, `80`
+- `automation/go2rtc-streams`
+  - old VIP: `10.0.81.14`
+  - new routed BGP VIP: `10.0.88.14`
+  - opt-in label: `lb-transport=bgp`
+  - TCP probes: `554`, `8555`
+  - UDP service: `8555`
+- `network/adguard-dns`
+  - old VIP: `10.0.81.10`
+  - new routed BGP VIP: `10.0.88.53` (because `10.0.88.10` is the existing echo canary)
+  - opt-in label: `lb-transport=bgp`
+  - TCP probes: `443`, `53`, `853`
+  - DNS UDP probe: `53`
+
+Prepared supporting changes:
+
+- Added final-wave TCP targets to `bgp-loadbalancer-tcp-probe`.
+- Added `bgp-loadbalancer-dns-probe` for AdGuard DNS UDP.
+- Raised `CiliumBGPAdvertisedRoutesExceeded` threshold from `8` to `15`, matching all approved current BGP VIP routes including Envoy and the canary.
+
+Validation before rollout:
+
+- `kustomize build` passed for:
+  - `kubernetes/apps/automation/mosquitto/app`
+  - `kubernetes/apps/automation/home-assistant/app`
+  - `kubernetes/apps/automation/go2rtc/app`
+  - `kubernetes/apps/media/plex/app`
+  - `kubernetes/apps/media/qbittorrent/app`
+  - `kubernetes/apps/network/adguard/app`
+  - `kubernetes/apps/network/ntpd/app`
+  - `kubernetes/apps/observability/blackbox-exporter/app`
+  - `kubernetes/apps/observability/kube-prometheus-stack/app`
+- Helm rendering with app-template `5.0.0` confirmed each final-wave Service remains `LoadBalancer`, has `lb-transport=bgp`, and uses the intended `10.0.88.x` VIP.
+
+Important rollout ordering:
+
+1. Upload/apply the UCG config first so live FRR uses the `10.0.88.0/24 ge 32 le 32` prefix-list and has no `maximum-prefix` line.
+2. Then merge/apply the GitOps changes.
+3. Validate route count, routes all within `10.0.88.0/24`, L2 lease absence for labelled Services, TCP/DNS probes, UDP spot checks, and alerts.

--- a/kubernetes/apps/automation/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/go2rtc/app/helmrelease.yaml
@@ -84,9 +84,11 @@ spec:
             port: *port
       streams:
         type: LoadBalancer
+        labels:
+          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: cameras.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.81.14
+          io.cilium/lb-ipam-ips: 10.0.88.14
         ports:
           streams-rtsp:
             port: 554

--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -111,9 +111,11 @@ spec:
         forceRename: *app
         controller: homeassistant
         type: LoadBalancer
+        labels:
+          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: hass-direct.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.81.4
+          io.cilium/lb-ipam-ips: 10.0.88.4
         ports:
           http:
             enabled: true

--- a/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
@@ -70,9 +70,11 @@ spec:
       app:
         type: LoadBalancer
         controller: mosquitto
+        labels:
+          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: mqtt.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.81.1
+          io.cilium/lb-ipam-ips: 10.0.88.1
         ports:
           http:
             port: 1883

--- a/kubernetes/apps/kube-system/cilium/ucg-cilium-bgp.conf
+++ b/kubernetes/apps/kube-system/cilium/ucg-cilium-bgp.conf
@@ -17,7 +17,6 @@ router bgp 64513
   neighbor K8S_CILIUM soft-reconfiguration inbound
   neighbor K8S_CILIUM route-map K8S_CILIUM_IN in
   neighbor K8S_CILIUM route-map K8S_CILIUM_OUT out
-  neighbor K8S_CILIUM maximum-prefix 8
   maximum-paths 5
  exit-address-family
 exit
@@ -32,11 +31,4 @@ exit
 route-map K8S_CILIUM_OUT deny 100
 exit
 
-ip prefix-list K8S_CILIUM_VIPS seq 10 permit 10.0.88.200/32
-ip prefix-list K8S_CILIUM_VIPS seq 20 permit 10.0.88.201/32
-ip prefix-list K8S_CILIUM_VIPS seq 30 permit 10.0.88.10/32
-ip prefix-list K8S_CILIUM_VIPS seq 40 permit 10.0.88.8/32
-ip prefix-list K8S_CILIUM_VIPS seq 50 permit 10.0.88.15/32
-ip prefix-list K8S_CILIUM_VIPS seq 60 permit 10.0.88.6/32
-ip prefix-list K8S_CILIUM_VIPS seq 70 permit 10.0.88.9/32
-ip prefix-list K8S_CILIUM_VIPS seq 80 permit 10.0.88.12/32
+ip prefix-list K8S_CILIUM_VIPS seq 10 permit 10.0.88.0/24 ge 32 le 32

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -97,9 +97,11 @@ spec:
       app:
         type: LoadBalancer
         controller: plex
+        labels:
+          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: plex-direct.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.81.3
+          io.cilium/lb-ipam-ips: 10.0.88.3
         externalTrafficPolicy: Cluster
         ports:
           http:

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -86,8 +86,10 @@ spec:
         controller: qbittorrent
         type: LoadBalancer
         externalTrafficPolicy: Cluster
+        labels:
+          lb-transport: bgp
         annotations:
-          io.cilium/lb-ipam-ips: 10.0.81.7
+          io.cilium/lb-ipam-ips: 10.0.88.7
         ports:
           http:
             port: *port

--- a/kubernetes/apps/network/adguard/app/helmrelease.yaml
+++ b/kubernetes/apps/network/adguard/app/helmrelease.yaml
@@ -49,9 +49,11 @@ spec:
       dns:
         controller: adguard
         type: LoadBalancer
+        labels:
+          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: dns.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.81.10
+          io.cilium/lb-ipam-ips: 10.0.88.53
         ports:
           dns-https:
             port: 443

--- a/kubernetes/apps/network/ntpd/app/helmrelease.yaml
+++ b/kubernetes/apps/network/ntpd/app/helmrelease.yaml
@@ -54,9 +54,11 @@ spec:
       app:
         type: LoadBalancer
         controller: ntpd
+        labels:
+          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: ntpd.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.81.5
+          io.cilium/lb-ipam-ips: 10.0.88.5
         externalTrafficPolicy: Cluster
         ports:
           ntpd:

--- a/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
@@ -174,6 +174,113 @@ spec:
         service: postgres
         vip: "10.0.88.12"
         port: "5432"
+    - targets:
+        - "10.0.88.1:1883"
+      labels:
+        probe: bgp-loadbalancer
+        service: mosquitto
+        vip: "10.0.88.1"
+        port: "1883"
+    - targets:
+        - "10.0.88.3:32400"
+      labels:
+        probe: bgp-loadbalancer
+        service: plex
+        vip: "10.0.88.3"
+        port: "32400"
+    - targets:
+        - "10.0.88.4:8123"
+      labels:
+        probe: bgp-loadbalancer
+        service: home-assistant
+        vip: "10.0.88.4"
+        port: "8123"
+    - targets:
+        - "10.0.88.4:21065"
+      labels:
+        probe: bgp-loadbalancer
+        service: home-assistant
+        vip: "10.0.88.4"
+        port: "21065"
+    - targets:
+        - "10.0.88.7:50413"
+      labels:
+        probe: bgp-loadbalancer
+        service: qbittorrent
+        vip: "10.0.88.7"
+        port: "50413"
+    - targets:
+        - "10.0.88.7:80"
+      labels:
+        probe: bgp-loadbalancer
+        service: qbittorrent
+        vip: "10.0.88.7"
+        port: "80"
+    - targets:
+        - "10.0.88.14:554"
+      labels:
+        probe: bgp-loadbalancer
+        service: go2rtc-streams
+        vip: "10.0.88.14"
+        port: "554"
+    - targets:
+        - "10.0.88.14:8555"
+      labels:
+        probe: bgp-loadbalancer
+        service: go2rtc-streams
+        vip: "10.0.88.14"
+        port: "8555"
+    - targets:
+        - "10.0.88.53:443"
+      labels:
+        probe: bgp-loadbalancer
+        service: adguard-dns
+        vip: "10.0.88.53"
+        port: "443"
+    - targets:
+        - "10.0.88.53:53"
+      labels:
+        probe: bgp-loadbalancer
+        service: adguard-dns
+        vip: "10.0.88.53"
+        port: "53"
+    - targets:
+        - "10.0.88.53:853"
+      labels:
+        probe: bgp-loadbalancer
+        service: adguard-dns
+        vip: "10.0.88.53"
+        port: "853"
+  relabelings:
+    - action: replace
+      sourceLabels: [__address__]
+      targetLabel: __param_target
+    - action: replace
+      sourceLabels: [__param_target]
+      targetLabel: instance
+    - action: replace
+      targetLabel: __address__
+      replacement: blackbox-exporter.observability.svc.cluster.local:9115
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: bgp-loadbalancer-dns-probe
+spec:
+  scrapeInterval: 30s
+  metricsPath: /probe
+  params:
+    module: ["dns_udp"]
+  staticConfigs:
+    - targets:
+        - "10.0.88.53:53"
+      labels:
+        probe: bgp-loadbalancer
+        service: adguard-dns
+        vip: "10.0.88.53"
+        port: "53"
+        protocol: udp
   relabelings:
     - action: replace
       sourceLabels: [__address__]

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/envoy-bgp-rules.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/envoy-bgp-rules.yaml
@@ -58,20 +58,27 @@ spec:
 
         - alert: CiliumBGPAdvertisedRoutesExceeded
           annotations:
-            summary: "Cilium BGP pod {{ $labels.pod }} is advertising more than the eight approved BGP LoadBalancer routes"
+            summary: "Cilium BGP pod {{ $labels.pod }} is advertising more than the fifteen approved BGP LoadBalancer routes"
             description: |
               Cilium BGP should only advertise the approved LoadBalancer VIPs during this phase:
+                - 10.0.88.1/32
+                - 10.0.88.3/32
+                - 10.0.88.4/32
+                - 10.0.88.5/32
+                - 10.0.88.6/32
+                - 10.0.88.7/32
+                - 10.0.88.8/32
+                - 10.0.88.9/32
+                - 10.0.88.10/32
+                - 10.0.88.12/32
+                - 10.0.88.14/32
+                - 10.0.88.15/32
+                - 10.0.88.53/32
                 - 10.0.88.200/32
                 - 10.0.88.201/32
-                - 10.0.88.10/32
-                - 10.0.88.8/32
-                - 10.0.88.15/32
-                - 10.0.88.6/32
-                - 10.0.88.9/32
-                - 10.0.88.12/32
 
-              This pod reports {{ $value }} advertised routes. The UCG inbound prefix-list should reject unexpected prefixes, but Cilium advertisement scope may have drifted and should be investigated before expanding BGP further.
-          expr: cilium_bgp_control_plane_advertised_routes > 8
+              This pod reports {{ $value }} advertised routes. The UCG inbound prefix-list should reject routes outside the routed LoadBalancer host-route range, but Cilium advertisement scope may have drifted and should be investigated before expanding BGP further.
+          expr: cilium_bgp_control_plane_advertised_routes > 15
           for: 2m
           labels:
             severity: critical


### PR DESCRIPTION
## Summary
- Move all remaining L2-backed LoadBalancer Services to the routed BGP prefix:
  - `automation/mosquitto` -> `10.0.88.1`
  - `media/plex` -> `10.0.88.3`
  - `automation/home-assistant` -> `10.0.88.4`
  - `network/ntpd` -> `10.0.88.5`
  - `media/qbittorrent` -> `10.0.88.7`
  - `automation/go2rtc-streams` -> `10.0.88.14`
  - `network/adguard-dns` -> `10.0.88.53`
- Add `lb-transport=bgp` to those Services so Cilium advertises them via the opt-in BGP selector and excludes them from L2 announcements.
- Change the UCG FRR repo config from exact per-VIP `/32`s plus `maximum-prefix` to a host-route-only `10.0.88.0/24` prefix-list:
  - `ip prefix-list K8S_CILIUM_VIPS seq 10 permit 10.0.88.0/24 ge 32 le 32`
  - remove `neighbor K8S_CILIUM maximum-prefix ...`
- Add final-wave blackbox TCP/DNS probes.
- Raise approved Cilium BGP route count from 8 to 15.
- Record final-wave prep in TODO-c7ae6934.

## Rollout order — do not merge before UCG is updated
1. Upload/apply the UCG BGP config first so live FRR has:
   - `ip prefix-list K8S_CILIUM_VIPS seq 10 permit 10.0.88.0/24 ge 32 le 32`
   - no `neighbor K8S_CILIUM maximum-prefix ...` line
2. Then merge this PR so Flux moves the remaining Services and Cilium advertises the additional `/32`s.
3. Validate UCG BGP routes, old/new VIP reachability, blackbox probes, UDP spot checks, and alerts.

## Validation
- `kustomize build` for all modified app directories and observability rule/probe directories.
- `helm template ... app-template --version 5.0.0` for all final-wave app-template Services.
