### PR TITLE
fix(observability): drop inactive HomeKit BGP probe

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
@@ -196,13 +196,6 @@ spec:
         vip: "10.0.88.4"
         port: "8123"
     - targets:
-        - "10.0.88.4:21065"
-      labels:
-        probe: bgp-loadbalancer
-        service: home-assistant
-        vip: "10.0.88.4"
-        port: "21065"
-    - targets:
         - "10.0.88.7:50413"
       labels:
         probe: bgp-loadbalancer


### PR DESCRIPTION
## Summary
- Remove the direct Home Assistant HomeKit TCP socket from the BGP blackbox probe list.
- The Service still exposes the port as before, but the TCP health probe returns connection refused, so keeping it in blackbox would create a false alert.
- The primary Home Assistant direct HTTP probe remains covered at `10.0.88.4:8123`.

## Validation
- `kustomize build kubernetes/apps/observability/blackbox-exporter/app`
