### PR TITLE
fix(cilium): advertise all loadbalancers over BGP

### DIFF
--- a/kubernetes/apps/automation/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/go2rtc/app/helmrelease.yaml
@@ -84,8 +84,6 @@ spec:
             port: *port
       streams:
         type: LoadBalancer
-        labels:
-          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: cameras.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.14

--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -111,8 +111,6 @@ spec:
         forceRename: *app
         controller: homeassistant
         type: LoadBalancer
-        labels:
-          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: hass-direct.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.4

--- a/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
@@ -70,8 +70,6 @@ spec:
       app:
         type: LoadBalancer
         controller: mosquitto
-        labels:
-          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: mqtt.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.1

--- a/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgres
-  labels:
-    lb-transport: bgp
   annotations:
     external-dns.alpha.kubernetes.io/hostname: postgres.${SECRET_DOMAIN}
     io.cilium/lb-ipam-ips: 10.0.88.12

--- a/kubernetes/apps/gdb/gdb/database/service.yaml
+++ b/kubernetes/apps/gdb/gdb/database/service.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gdb-postgres
-  labels:
-    lb-transport: bgp
   annotations:
     external-dns.alpha.kubernetes.io/hostname: gdb-postgres.${SECRET_DOMAIN}
     io.cilium/lb-ipam-ips: 10.0.88.15

--- a/kubernetes/apps/kube-system/cilium/app/bgp.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/bgp.yaml
@@ -9,7 +9,7 @@ spec:
       safi: unicast
       advertisements:
         matchLabels:
-          advertise: bgp-envoy
+          advertise: bgp
 ---
 apiVersion: cilium.io/v2
 kind: CiliumBGPClusterConfig
@@ -32,9 +32,9 @@ spec:
 apiVersion: cilium.io/v2
 kind: CiliumBGPAdvertisement
 metadata:
-  name: envoy-loadbalancers
+  name: loadbalancers
   labels:
-    advertise: bgp-envoy
+    advertise: bgp
 spec:
   advertisements:
     - advertisementType: Service
@@ -43,28 +43,8 @@ spec:
           - LoadBalancerIP
       selector:
         matchExpressions:
-          - key: io.kubernetes.service.namespace
-            operator: In
-            values:
-              - network
+          # Match all Services. Only Services with LoadBalancer IPs are advertised.
           - key: io.kubernetes.service.name
-            operator: In
+            operator: NotIn
             values:
-              - envoy-internal
-              - envoy-external
----
-apiVersion: cilium.io/v2
-kind: CiliumBGPAdvertisement
-metadata:
-  name: labelled-loadbalancers
-  labels:
-    advertise: bgp-envoy
-spec:
-  advertisements:
-    - advertisementType: Service
-      service:
-        addresses:
-          - LoadBalancerIP
-      selector:
-        matchLabels:
-          lb-transport: bgp
+              - never-used-service-name

--- a/kubernetes/apps/kube-system/cilium/app/network.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/network.yaml
@@ -1,28 +1,4 @@
 ---
-# https://docs.cilium.io/en/latest/network/l2-announcements
-apiVersion: cilium.io/v2alpha1
-kind: CiliumL2AnnouncementPolicy
-metadata:
-  name: policy
-spec:
-  loadBalancerIPs: true
-  serviceSelector:
-    matchExpressions:
-      - key: gateway.networking.k8s.io/gateway-name
-        operator: NotIn
-        values:
-          - envoy-internal
-          - envoy-external
-      - key: lb-transport
-        operator: NotIn
-        values:
-          - bgp
-  interfaces:
-    - bond0
-  nodeSelector:
-    matchLabels:
-      kubernetes.io/os: linux
----
 apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool
 metadata:
@@ -30,5 +6,4 @@ metadata:
 spec:
   allowFirstLastIPs: "Yes"
   blocks:
-    - cidr: "10.0.80.0/21"
     - cidr: "10.0.88.0/24"

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -97,8 +97,6 @@ spec:
       app:
         type: LoadBalancer
         controller: plex
-        labels:
-          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: plex-direct.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.3

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -86,8 +86,6 @@ spec:
         controller: qbittorrent
         type: LoadBalancer
         externalTrafficPolicy: Cluster
-        labels:
-          lb-transport: bgp
         annotations:
           io.cilium/lb-ipam-ips: 10.0.88.7
         ports:

--- a/kubernetes/apps/network/adguard/app/helmrelease.yaml
+++ b/kubernetes/apps/network/adguard/app/helmrelease.yaml
@@ -49,8 +49,6 @@ spec:
       dns:
         controller: adguard
         type: LoadBalancer
-        labels:
-          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: dns.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.53

--- a/kubernetes/apps/network/ntpd/app/helmrelease.yaml
+++ b/kubernetes/apps/network/ntpd/app/helmrelease.yaml
@@ -54,8 +54,6 @@ spec:
       app:
         type: LoadBalancer
         controller: ntpd
-        labels:
-          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: ntpd.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.5

--- a/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
@@ -53,8 +53,6 @@ spec:
       app:
         type: LoadBalancer
         controller: smtp-relay
-        labels:
-          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: smtp.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.6

--- a/kubernetes/apps/observability/influxdb/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/influxdb/app/helmrelease.yaml
@@ -56,8 +56,6 @@ spec:
       app:
         type: LoadBalancer
         controller: influxdb
-        labels:
-          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: influx-direct.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.9

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/bgp-loadbalancer-rules.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/bgp-loadbalancer-rules.yaml
@@ -20,7 +20,6 @@ spec:
               Check UCG BGP routes and the affected Service endpoints:
                 ssh root@10.0.0.1 'vtysh -c "show bgp ipv4 unicast summary" -c "show ip route bgp"'
                 kubectl get svc -A --field-selector spec.type=LoadBalancer -o wide
-                kubectl get svc -A -l lb-transport=bgp -o wide
                 kubectl get endpointslice -A -l kubernetes.io/service-name={{ if $labels.service }}{{ $labels.service }}{{ else }}{{ $labels.gateway }}{{ end }} -o wide
           expr: min_over_time(probe_success{probe=~"envoy-vip|bgp-loadbalancer"}[2m]) == 0
           for: 1m

--- a/kubernetes/apps/observability/vector/app/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/app/aggregator/helmrelease.yaml
@@ -42,8 +42,6 @@ spec:
       app:
         type: LoadBalancer
         controller: vector-aggregator
-        labels:
-          lb-transport: bgp
         annotations:
           external-dns.alpha.kubernetes.io/hostname: vector.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.8


### PR DESCRIPTION
## Summary
- collapse Cilium BGP advertisements to a single all-LoadBalancer Service selector
- retire the Cilium L2 LoadBalancer announcement policy and old IP pool range
- remove now-redundant `lb-transport=bgp` labels from LoadBalancer Services
- update the BGP probe alert runbook text

## Validation
- `kustomize build` for cilium and all modified app/observability kustomizations
- rendered Cilium config has no L2 policy, old advertisement names, or `lb-transport` selectors
