### PR TITLE
feat: add Bambuddy

### DIFF
--- a/kubernetes/apps/automation/bambuddy/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/bambuddy/app/helmrelease.yaml
@@ -1,0 +1,105 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bambuddy
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      bambuddy:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/maziggy/bambuddy
+              tag: 0.2.4@sha256:c3f7f758f0b6ac2a074e7277074b2d0150dfe81b190a44b551ab092a5d17ca6c
+            env:
+              TZ: ${TZ}
+              PUID: 568
+              PGID: 568
+              HOME: /tmp
+              PORT: &port 8000
+              LOG_LEVEL: INFO
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+        pod:
+          securityContext:
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: bambuddy
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - bambuddy.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      data:
+        enabled: true
+        existingClaim: bambuddy
+        advancedMounts:
+          bambuddy:
+            app:
+              - path: /app/data
+                subPath: data
+              - path: /app/logs
+                subPath: logs
+      tmp:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/automation/bambuddy/app/kustomization.yaml
+++ b/kubernetes/apps/automation/bambuddy/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+components:
+  - ../../../../components/authelia-proxy

--- a/kubernetes/apps/automation/bambuddy/ks.yaml
+++ b/kubernetes/apps/automation/bambuddy/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bambuddy
+  namespace: &namespace automation
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: authelia
+      namespace: security
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/automation/bambuddy/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # no flux ks dependents
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_KOPIA_SCHEDULE: "17 * * * *"
+      VOLSYNC_R2_SCHEDULE: "41 2 * * *"

--- a/kubernetes/apps/automation/kustomization.yaml
+++ b/kubernetes/apps/automation/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: automation
 components:
   - ../../components/common
 resources:
+  - ./bambuddy/ks.yaml
   - ./changedetection/ks.yaml
   - ./esphome/ks.yaml
   - ./fernwood-booker/ks.yaml


### PR DESCRIPTION
## Summary
- add Bambuddy to the `automation` namespace using the bjw-s app-template chart
- expose it internally at `bambuddy.${SECRET_DOMAIN}` behind Authelia
- add a VolSync-backed `/app/data` + `/app/logs` PVC
- pin Bambuddy to `0.2.4` by digest

## Validation
- `kustomize build kubernetes/apps/automation >/tmp/automation.yaml`
- `helm template bambuddy oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.0 -n automation -f /tmp/bambuddy-values.yaml --include-crds >/tmp/bambuddy-rendered.yaml`
- GitHub Actions: Flux Local - Test / Diff passed

## Deploy notes
This PR only submits the GitOps manifests. Do not merge/deploy until approved.
