### PR TITLE
fix: run Bambuddy as non-root

### DIFF
--- a/kubernetes/apps/automation/bambuddy/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/bambuddy/app/helmrelease.yaml
@@ -72,6 +72,9 @@ spec:
                 memory: 1Gi
         pod:
           securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            runAsNonRoot: true
             fsGroup: 568
             fsGroupChangePolicy: OnRootMismatch
     service:


### PR DESCRIPTION
## Summary
- run the Bambuddy pod as uid/gid 568 so the upstream entrypoint skips its root-only `chown`/`gosu` path
- keep `fsGroup` for PVC write access

## Why
The initial install crash-looped because the container started as root with all capabilities dropped, then the upstream entrypoint failed to `chown` and `gosu`.

## Validation
- `kustomize build kubernetes/apps/automation >/tmp/automation.yaml`
- `helm template bambuddy oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.0 -n automation -f /tmp/bambuddy-values.yaml --include-crds >/tmp/bambuddy-rendered.yaml`
