### PR TITLE
fix: allow Bambuddy Python file capability

### DIFF
--- a/kubernetes/apps/automation/bambuddy/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/bambuddy/app/helmrelease.yaml
@@ -59,11 +59,15 @@ spec:
                   timeoutSeconds: 5
                   failureThreshold: 30
             securityContext:
-              allowPrivilegeEscalation: false
+              # Upstream sets cap_net_bind_service on Python; the container must allow
+              # that file capability at exec time even though Bambuddy only serves :8000 here.
+              allowPrivilegeEscalation: true
               readOnlyRootFilesystem: true
               capabilities:
                 drop:
                   - ALL
+                add:
+                  - NET_BIND_SERVICE
             resources:
               requests:
                 cpu: 50m


### PR DESCRIPTION
## Summary
- allow the Bambuddy container to execute upstream's file-capability Python binary by adding `NET_BIND_SERVICE`
- document why `allowPrivilegeEscalation` has to be true for this image

## Why
After the non-root fix, the pod progressed past the entrypoint but crashed with:

```text
sh: 1: uvicorn: Operation not permitted
```

The Bambuddy image sets `cap_net_bind_service=+ep` on Python. With `no_new_privs` and all caps dropped, Linux refuses to exec that capability-bearing interpreter.

## Validation
- `kustomize build kubernetes/apps/automation >/tmp/automation.yaml`
- `helm template bambuddy oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.0 -n automation -f /tmp/bambuddy-values.yaml --include-crds >/tmp/bambuddy-rendered.yaml`
