### PR TITLE
fix(plex): preserve client IPs for Tracearr

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -100,7 +100,9 @@ spec:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: plex-direct.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.3
-        externalTrafficPolicy: Cluster
+        # Preserve the real client IP for direct Plex connections so
+        # Plex/Tracearr don't classify remote streams as local.
+        externalTrafficPolicy: Local
         ports:
           http:
             port: 32400
@@ -111,6 +113,21 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - filters:
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  set:
+                    # Envoy already appends X-Forwarded-For with the
+                    # real client IP. Add the remaining proxy context
+                    # Plex/Tracearr expect for geolocation.
+                    - name: X-Forwarded-Proto
+                      value: https
+                    - name: X-Forwarded-Host
+                      value: plex.${SECRET_DOMAIN}
+            backendRefs:
+              - identifier: app
+                port: http
     persistence:
       config:
         enabled: true


### PR DESCRIPTION
## Summary
- Preserve the real client IP for direct Plex LoadBalancer traffic by switching the Plex service to `externalTrafficPolicy: Local`.
- Add `X-Forwarded-Proto` and `X-Forwarded-Host` on the Envoy-backed Plex HTTPRoute; Envoy already appends `X-Forwarded-For`.

## Context
Tracearr marks every active Plex stream as local because Plex is reporting remote clients as `10.0.87.1` / `local=1`. Live Plex logs confirmed active remote playback requests arriving from `10.0.87.1`, which matches the UCG BGP peer/router address rather than the client public IP.

## Validation
- Queried Plex `/status/sessions`: active sessions reported `address=10.0.87.1 local=1`.
- Confirmed existing Envoy route forwards `X-Forwarded-For` and `X-Forwarded-Proto`, but not `X-Forwarded-Host`.
- Parsed the edited YAML with PyYAML.
- Rendered the app-template Helm chart with the updated values and verified the generated HTTPRoute contains the request header modifier.
- Server-side dry-run of the HTTPRoute filter passed with `kubectl apply --dry-run=server`.

After merge/deploy, verify with Plex `/status/sessions` during a remote stream; the `Player address` should be the remote public IP and `local` should no longer be `1`.
