### PR TITLE
fix(plex): exclude UCG peer from LAN networks

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -31,8 +31,15 @@ spec:
               tag: 1.43.1.10611@sha256:a9c3723cb31cc9621df27cf5801184c290293adf1df2bfaea4b8b6fc01dbfd96
             env:
               TZ: ${TZ}
-              PLEX_ADVERTISE_URL: https://plex.${SECRET_DOMAIN}:443,http://plex-direct.${SECRET_DOMAIN}:32400,http://10.0.81.3:32400
-              PLEX_NO_AUTH_NETWORKS: 10.0.0.0/16,10.69.0.0/16
+              PLEX_ADVERTISE_URL: https://plex.${SECRET_DOMAIN}:443,http://plex-direct.${SECRET_DOMAIN}:32400,http://10.0.88.3:32400
+              # Keep the UCG BGP peer (10.0.87.1) out of Plex's local
+              # network lists. UniFi SNATs remote Plex-direct sessions
+              # to that address, and if Plex treats it as LAN then
+              # Tracearr records every remote stream as local.
+              PLEX_NO_AUTH_NETWORKS: >-
+                10.0.0.0/24,10.0.10.0/23,10.0.20.0/22,10.0.30.0/24,10.0.40.0/24,10.0.50.0/23,10.0.80.0/22,10.0.84.0/23,10.0.86.0/24,10.2.1.0/24,10.69.0.0/16
+              PLEX_PREFERENCE_LAN_NETWORKS: >-
+                LanNetworksBandwidth=10.0.0.0/24,10.0.10.0/23,10.0.20.0/22,10.0.30.0/24,10.0.40.0/24,10.0.50.0/23,10.2.1.0/24
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
## Summary
- Narrow Plex `allowedNetworks` so the UCG BGP peer `10.0.87.1` is not treated as a trusted/local client.
- Set Plex `LanNetworksBandwidth` via `PLEX_PREFERENCE_LAN_NETWORKS`, also excluding `10.0.87.1`.
- Correct the advertised direct LoadBalancer IP from the old `10.0.81.3` value to `10.0.88.3`.

## Context
After PR #2656 was merged and deployed, a fresh remote Plex stream still showed:

- `Player address=10.0.87.1`
- `remotePublicAddress=<home WAN IP>`
- `local=1`
- `Session location=lan`

Tracearr uses `remotePublicAddress` only when Plex reports `local=false`; otherwise it intentionally uses the local `Player.address`. Plex preferences currently had `allowedNetworks=10.0.0.0/8,10.69.0.0/16` and `LanNetworksBandwidth=10.0.0.0/8`, so the UniFi SNAT/BGP peer address was being classified as LAN.

## Validation
- Parsed YAML with PyYAML.
- Rendered app-template Helm chart and verified the updated env values render into the Deployment.
- Temporarily applied the same Plex preference values live via Plex `/:/prefs` API so the next fresh remote session can be tested immediately.
