### PR TITLE
fix(cilium): align UCG BGP with onedr0p

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
@@ -26,7 +26,7 @@ k8sServicePort: 7445
 kubeProxyReplacement: true
 kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
 l2announcements:
-  enabled: true
+  enabled: false
 loadBalancer:
   algorithm: maglev
   mode: dsr

--- a/kubernetes/apps/kube-system/cilium/ucg-cilium-bgp.conf
+++ b/kubernetes/apps/kube-system/cilium/ucg-cilium-bgp.conf
@@ -1,34 +1,18 @@
 router bgp 64513
  bgp router-id 10.0.87.1
- no bgp default ipv4-unicast
+ no bgp ebgp-requires-policy
 
- neighbor K8S_CILIUM peer-group
- neighbor K8S_CILIUM remote-as 64514
- neighbor K8S_CILIUM description Cilium Kubernetes nodes
+ neighbor k8s peer-group
+ neighbor k8s remote-as 64514
 
- neighbor 10.0.80.10 peer-group K8S_CILIUM
- neighbor 10.0.80.11 peer-group K8S_CILIUM
- neighbor 10.0.80.12 peer-group K8S_CILIUM
- neighbor 10.0.80.13 peer-group K8S_CILIUM
- neighbor 10.0.80.14 peer-group K8S_CILIUM
+ neighbor 10.0.80.10 peer-group k8s
+ neighbor 10.0.80.11 peer-group k8s
+ neighbor 10.0.80.12 peer-group k8s
+ neighbor 10.0.80.13 peer-group k8s
+ neighbor 10.0.80.14 peer-group k8s
 
  address-family ipv4 unicast
-  neighbor K8S_CILIUM activate
-  neighbor K8S_CILIUM soft-reconfiguration inbound
-  neighbor K8S_CILIUM route-map K8S_CILIUM_IN in
-  neighbor K8S_CILIUM route-map K8S_CILIUM_OUT out
-  maximum-paths 5
+  neighbor k8s next-hop-self
+  neighbor k8s soft-reconfiguration inbound
  exit-address-family
 exit
-
-route-map K8S_CILIUM_IN permit 10
- match ip address prefix-list K8S_CILIUM_VIPS
-exit
-
-route-map K8S_CILIUM_IN deny 100
-exit
-
-route-map K8S_CILIUM_OUT deny 100
-exit
-
-ip prefix-list K8S_CILIUM_VIPS seq 10 permit 10.0.88.0/24 ge 32 le 32


### PR DESCRIPTION
## Summary
- Align the documented UniFi/UCG FRR BGP config with onedr0p's simpler UDM setup.
- Remove explicit route-map/prefix-list policy and `maximum-paths` from the UCG sample config.
- Add `no bgp ebgp-requires-policy` and `next-hop-self` to match onedr0p's BGP peer-group shape.
- Disable Cilium L2 announcements so LoadBalancer exposure is BGP-only like onedr0p.

## Validation
- `kubectl kustomize kubernetes/apps/kube-system/cilium/app >/tmp/cilium-render.yaml`
- Confirmed rendered Cilium values contain `l2announcements.enabled: false`.

## Notes
- This only changes Git. I have not applied the UCG FRR config over SSH.
