### PR TITLE
test(plex): use cluster external traffic policy

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -105,9 +105,9 @@ spec:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: plex-direct.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: 10.0.88.3
-        # Preserve the real client IP for direct Plex connections so
-        # Plex/Tracearr don't classify remote streams as local.
-        externalTrafficPolicy: Local
+        # Test whether Cilium DSR preserves remote client IPs for Plex
+        # when the BGP VIP is advertised from all nodes.
+        externalTrafficPolicy: Cluster
         ports:
           http:
             port: 32400


### PR DESCRIPTION
## Summary
- Temporarily switch Plex LoadBalancer `externalTrafficPolicy` from `Local` to `Cluster`.
- Keep the BGP VIP and stable nodePort unchanged.
- Intended to test whether Cilium DSR preserves the real remote client IP when the VIP is advertised from all nodes.

## Validation
- `kubectl kustomize kubernetes/apps/media/plex/app >/tmp/plex-render.yaml`
- Confirmed rendered Service has `externalTrafficPolicy: Cluster` and `nodePort: 32400`.

## Notes
- This is a test PR for the UniFi/Cilium/Plex source-IP investigation.
- No live apply has been performed from this branch.
