### PR TITLE
fix(mosquitto): move VIP off gateway address

### DIFF
--- a/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
@@ -72,7 +72,7 @@ spec:
         controller: mosquitto
         annotations:
           external-dns.alpha.kubernetes.io/hostname: mqtt.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.88.1
+          io.cilium/lb-ipam-ips: 10.0.88.2
         ports:
           http:
             port: 1883

--- a/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/scrapeconfig.yaml
@@ -146,11 +146,11 @@ spec:
         vip: "10.0.88.12"
         port: "5432"
     - targets:
-        - "10.0.88.1:1883"
+        - "10.0.88.2:1883"
       labels:
         probe: bgp-loadbalancer
         service: mosquitto
-        vip: "10.0.88.1"
+        vip: "10.0.88.2"
         port: "1883"
     - targets:
         - "10.0.88.3:32400"


### PR DESCRIPTION
## Summary
- Move Mosquitto's Cilium LoadBalancer VIP from `10.0.88.1` to `10.0.88.2`.
- Update the blackbox BGP LoadBalancer probe to match the new VIP.

## Why
- Frees `10.0.88.1` so it can be used as the UniFi gateway address if we test making `10.0.88.0/24` a first-class UniFi network/VLAN for the BGP VIP source-IP investigation.

## Validation
- `rg -n "10\\.0\\.88\\.1(?![0-9])" kubernetes/apps -P || true`
- `kubectl kustomize kubernetes/apps/automation/mosquitto/app >/tmp/mosquitto-render.yaml`
- `kubectl kustomize kubernetes/apps/observability/blackbox-exporter/app >/tmp/blackbox-render.yaml`
