### PR TITLE
chore(cilium): standardize lb ipam annotations

### DIFF
--- a/kubernetes/apps/automation/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/go2rtc/app/helmrelease.yaml
@@ -86,7 +86,7 @@ spec:
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: cameras.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.88.14
+          lbipam.cilium.io/ips: 10.0.88.14
         ports:
           streams-rtsp:
             port: 554

--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -113,7 +113,7 @@ spec:
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: hass-direct.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.88.4
+          lbipam.cilium.io/ips: 10.0.88.4
         ports:
           http:
             enabled: true

--- a/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/mosquitto/app/helmrelease.yaml
@@ -72,7 +72,7 @@ spec:
         controller: mosquitto
         annotations:
           external-dns.alpha.kubernetes.io/hostname: mqtt.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.88.2
+          lbipam.cilium.io/ips: 10.0.88.2
         ports:
           http:
             port: 1883

--- a/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: postgres
   annotations:
     external-dns.alpha.kubernetes.io/hostname: postgres.${SECRET_DOMAIN}
-    io.cilium/lb-ipam-ips: 10.0.88.12
+    lbipam.cilium.io/ips: 10.0.88.12
 spec:
   type: LoadBalancer
   ports:

--- a/kubernetes/apps/gdb/gdb/database/service.yaml
+++ b/kubernetes/apps/gdb/gdb/database/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gdb-postgres
   annotations:
     external-dns.alpha.kubernetes.io/hostname: gdb-postgres.${SECRET_DOMAIN}
-    io.cilium/lb-ipam-ips: 10.0.88.15
+    lbipam.cilium.io/ips: 10.0.88.15
 spec:
   type: LoadBalancer
   ports:

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -87,7 +87,7 @@ spec:
         type: LoadBalancer
         externalTrafficPolicy: Cluster
         annotations:
-          io.cilium/lb-ipam-ips: 10.0.88.7
+          lbipam.cilium.io/ips: 10.0.88.7
         ports:
           http:
             port: *port

--- a/kubernetes/apps/network/adguard/app/helmrelease.yaml
+++ b/kubernetes/apps/network/adguard/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: dns.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.88.53
+          lbipam.cilium.io/ips: 10.0.88.53
         ports:
           dns-https:
             port: 443

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -52,7 +52,7 @@ spec:
   gatewayClassName: envoy
   infrastructure:
     annotations:
-      io.cilium/lb-ipam-ips: "10.0.88.200"
+      lbipam.cilium.io/ips: "10.0.88.200"
   listeners:
     - name: http
       protocol: HTTP
@@ -83,7 +83,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
-      io.cilium/lb-ipam-ips: "10.0.88.201"
+      lbipam.cilium.io/ips: "10.0.88.201"
   listeners:
     - name: http
       protocol: HTTP

--- a/kubernetes/apps/network/ntpd/app/helmrelease.yaml
+++ b/kubernetes/apps/network/ntpd/app/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
         controller: ntpd
         annotations:
           external-dns.alpha.kubernetes.io/hostname: ntpd.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.88.5
+          lbipam.cilium.io/ips: 10.0.88.5
         externalTrafficPolicy: Cluster
         ports:
           ntpd:

--- a/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
         controller: smtp-relay
         annotations:
           external-dns.alpha.kubernetes.io/hostname: smtp.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.88.6
+          lbipam.cilium.io/ips: 10.0.88.6
         ports:
           http:
             port: 25

--- a/kubernetes/apps/observability/influxdb/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/influxdb/app/helmrelease.yaml
@@ -58,7 +58,7 @@ spec:
         controller: influxdb
         annotations:
           external-dns.alpha.kubernetes.io/hostname: influx-direct.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.88.9
+          lbipam.cilium.io/ips: 10.0.88.9
         externalTrafficPolicy: Cluster
         ports:
           http:

--- a/kubernetes/apps/observability/vector/app/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/app/aggregator/helmrelease.yaml
@@ -44,7 +44,7 @@ spec:
         controller: vector-aggregator
         annotations:
           external-dns.alpha.kubernetes.io/hostname: vector.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: 10.0.88.8
+          lbipam.cilium.io/ips: 10.0.88.8
         ports:
           http:
             port: 8686


### PR DESCRIPTION
## Summary
- Replace legacy `io.cilium/lb-ipam-ips` annotations with `lbipam.cilium.io/ips` across LoadBalancer services/Gateways.
- Leaves assigned VIPs unchanged.

## Validation
- `rg -n "io\\.cilium/lb-ipam-ips|lbipam\\.cilium\\.io/ips" kubernetes/apps`
- `kubectl kustomize` for each changed app path.
