### PR TITLE
fix(helm): replace Envoy Gateway CRDs during upgrades

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -9,8 +9,11 @@ spec:
     kind: OCIRepository
     name: envoy-gateway
   install:
+    crds: CreateReplace
     remediation:
       retries: -1
+  upgrade:
+    crds: CreateReplace
   interval: 1h
   values:
     config:


### PR DESCRIPTION
## Summary
- ensure Envoy Gateway CRDs are CreateReplace'd on install/upgrade
- fixes v1.8.0 controller crash on missing `gateway.networking.k8s.io/v1` TLSRoute CRD

## Validation
- observed new Envoy Gateway pod crashing with `no matches for kind "TLSRoute" in version "gateway.networking.k8s.io/v1"`
