### PR TITLE
fix(helm): stop retrying Envoy Gateway CRD replacement

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -12,8 +12,6 @@ spec:
     crds: CreateReplace
     remediation:
       retries: -1
-  upgrade:
-    crds: CreateReplace
   interval: 1h
   values:
     config:


### PR DESCRIPTION
## Summary
- keep install-time CRD replacement for fresh installs
- stop retrying CRD replacement on every upgrade now that Gateway API CRDs include TLSRoute v1
- unblocks Envoy Gateway HelmRelease after v1.8.0 rollout

## Validation
- previous hotfix updated `tlsroutes.gateway.networking.k8s.io` to include `v1`
- Envoy Gateway new pod no longer crashes on missing TLSRoute v1
