### PR TITLE
fix(kubernetes): increase intel gpu sharing headroom

### DIFF
--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -73,6 +73,17 @@ spec:
                   - matchExpressions:
                       - key: node-role.kubernetes.io/worker
                         operator: Exists
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/name
+                          operator: In
+                          values: ["plex"]
+                    namespaces: ["media"]
+                    topologyKey: kubernetes.io/hostname
           nodeSelector:
             google.feature.node.kubernetes.io/coral: "true"
     service:

--- a/kubernetes/apps/kube-system/intel-device-plugin/gpu/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/gpu/helmrelease.yaml
@@ -20,5 +20,5 @@ spec:
     keepHistory: false
   values:
     name: intel-gpu-plugin
-    sharedDevNum: 3
+    sharedDevNum: 4
     nodeFeatureRule: false

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -83,6 +83,17 @@ spec:
                         values: ["true"]
                       - key: node-role.kubernetes.io/worker
                         operator: Exists
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/name
+                          operator: In
+                          values: ["frigate"]
+                    namespaces: ["automation"]
+                    topologyKey: kubernetes.io/hostname
           nodeSelector:
             intel.feature.node.kubernetes.io/gpu: "true"
           securityContext:


### PR DESCRIPTION
## Plan
- Scrap the PriorityClass/preemption approach.
- Increase Intel GPU logical sharing so node drains/rollouts have spare `gpu.intel.com/i915` capacity.
- Keep Plex and Frigate separated in normal operation with cross-namespace preferred pod anti-affinity.
- Use preferred, not required, anti-affinity so a node upgrade can still temporarily co-locate them if only one suitable worker remains.

## Summary
- Increased Intel device plugin `sharedDevNum` from `3` to `4`.
- Added high-weight preferred anti-affinity from Plex to Frigate across `media`/`automation` namespaces.
- Added matching preferred anti-affinity from Frigate to Plex.
- Removed the previously proposed PriorityClass/preemption changes.

## Validation
- `kustomize build kubernetes/apps/kube-system`
- `kustomize build kubernetes/apps/media/plex/app`
- `kustomize build kubernetes/apps/automation/frigate/app`
- `helm template` for Plex and Frigate app-template values confirmed anti-affinity renders into pod specs.
