### PR TITLE
feat(gdb): update scraper to 0.1.75

### DIFF
--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           scraper:
             image: &image
               repository: ghcr.io/adampetrovic/gdb-scraper
-              tag: 0.1.72@sha256:e94b4f59740ec3408ba2e82d862fac9db10b21701773e787a5094d2c61c5cac8
+              tag: 0.1.75@sha256:f8ef14dc8b949e1add7895b3de5901d7d970a97d2df7c1c5b19a564b3073378c
             envFrom:
               - secretRef:
                   name: gdb-secret


### PR DESCRIPTION
## Summary
- update gdb-scraper image to 0.1.75 for MMS current-year replay snapshot support

## Validation
- `poetry run pytest -q` in gdb-scraper: 104 passed
- CI/CD for gdb-scraper 0.1.75 completed successfully
