### PR TITLE
feat(observability): add internal Gatus route monitoring

### DIFF
--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -140,6 +140,8 @@ spec:
               - identifier: app
                 port: http
       external:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - "hass.${SECRET_PUBLIC_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/default/babybuddy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/babybuddy/app/helmrelease.yaml
@@ -58,6 +58,8 @@ spec:
           - name: envoy-internal
             namespace: network
       external:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - "baby.${SECRET_PUBLIC_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/default/miniflux/app/helmrelease.yaml
+++ b/kubernetes/apps/default/miniflux/app/helmrelease.yaml
@@ -95,6 +95,8 @@ spec:
             port: *port
     route:
       app:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - miniflux.${SECRET_PUBLIC_DOMAIN}
         parentRefs:

--- a/kubernetes/apps/default/readeck/app/helmrelease.yaml
+++ b/kubernetes/apps/default/readeck/app/helmrelease.yaml
@@ -71,6 +71,8 @@ spec:
             port: *port
     route:
       app:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - "readeck.${SECRET_PUBLIC_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -151,6 +151,8 @@ spec:
 
     route:
       external:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - "photos.${SECRET_PUBLIC_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo-server/app/helmrelease.yaml
@@ -84,6 +84,8 @@ spec:
             scrapeTimeout: 10s
     route:
       main:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_PUBLIC_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -78,6 +78,14 @@ metadata:
   name: envoy-external
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname "external.${SECRET_PUBLIC_DOMAIN}"
+    gatus.home-operations.com/endpoint: |-
+      client:
+        dns-resolver: tcp://1.1.1.1:53
+      group: external
+      interval: 1m
+      conditions:
+        - "[STATUS] < 400"
+        - "[RESPONSE_TIME] < 5000"
 spec:
   gatewayClassName: envoy
   infrastructure:

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -1,0 +1,149 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app gatus
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      gatus:
+        type: statefulset
+        replicas: 1
+        serviceAccount:
+          identifier: *app
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          gatus-sidecar:
+            image:
+              repository: ghcr.io/home-operations/gatus-sidecar
+              tag: 0.0.14@sha256:b77e0a1267708a555640b81dd8a9baa2a197c2f34647dc4ac053eb812d4b31cc
+            args:
+              - --enable-httproute
+              - --gateway-name=envoy-external
+              - --output=/config/gatus-sidecar.yaml
+              - --default-interval=1m
+            restartPolicy: Always
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 64Mi
+        containers:
+          app:
+            image:
+              repository: ghcr.io/twin/gatus
+              tag: v5.35.0@sha256:21609f31be8c4e680ce3004b24276305666239c99aff58391503f3fb6142f39d
+            env:
+              GATUS_CONFIG_PATH: /config
+              GATUS_DELAY_START_SECONDS: 5
+              GATUS_WEB_PORT: &port 8080
+              TZ: "${TZ}"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+    service:
+      app:
+        controller: gatus
+        forceRename: *app
+        ports:
+          http:
+            port: *port
+    serviceMonitor:
+      app:
+        serviceName: *app
+        endpoints:
+          - port: http
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/enabled: "false"
+        hostnames:
+          - "gatus.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    serviceAccount:
+      gatus: {}
+    rbac:
+      bindings:
+        gatus:
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: gatus
+          subjects:
+            - identifier: gatus
+      roles:
+        gatus:
+          type: ClusterRole
+          rules:
+            - apiGroups: ["gateway.networking.k8s.io"]
+              resources: ["gateways", "httproutes"]
+              verbs: ["get", "list", "watch"]
+    persistence:
+      config:
+        enabled: true
+        existingClaim: *app
+        globalMounts:
+          - path: /config
+      config-file:
+        enabled: true
+        type: configMap
+        name: gatus-configmap
+        globalMounts:
+          - path: /config/config.yaml
+            subPath: config.yaml
+            readOnly: true

--- a/kubernetes/apps/observability/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/observability/gatus/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./prometheusrule.yaml
+configMapGenerator:
+  - name: gatus-configmap
+    files:
+      - config.yaml=./resources/config.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/observability/gatus/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/gatus/app/prometheusrule.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: gatus-rules
+  labels:
+    prometheus: k8s
+    role: alert-rules
+spec:
+  groups:
+    - name: gatus.rules
+      rules:
+        - alert: GatusExternalEndpointDown
+          expr: gatus_results_endpoint_success{group="external"} == 0
+          for: 3m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Public route {{ $labels.name }} is failing its Gatus check"
+            description: "Gatus has not received a fast <400 response from {{ $labels.name }} for 3 minutes. Check Cloudflare Tunnel, external Envoy, and the backend Service endpoints."

--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -1,0 +1,21 @@
+---
+web:
+  port: ${GATUS_WEB_PORT}
+
+metrics: true
+debug: false
+
+storage:
+  type: sqlite
+  path: ${GATUS_CONFIG_PATH}/sqlite.db
+  caching: true
+
+connectivity:
+  checker:
+    target: 1.1.1.1:53
+    interval: 1m
+
+ui:
+  title: Status | Route Health
+  header: Route Health
+  default-sort-by: group

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gatus
+  namespace: &namespace observability
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
+    - name: envoy-gateway
+      namespace: network
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/observability/gatus/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_KOPIA_SCHEDULE: "45 * * * *"
+      VOLSYNC_R2_SCHEDULE: "50 3 * * *"

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/resources/alertmanager.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/resources/alertmanager.yaml
@@ -52,7 +52,7 @@ inhibit_rules:
   - source_matchers:
       - alertname =~ "WANDown|WANDownBuffer"
     target_matchers:
-      - alertname =~ "KubePodCrashLooping|KubeDeploymentReplicasMismatch|KubePodNotReady|TargetDown"
+      - alertname =~ "KubePodCrashLooping|KubeDeploymentReplicasMismatch|KubePodNotReady|TargetDown|GatusExternalEndpointDown"
 receivers:
   - name: "null"
   - name: homeassistant

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 resources:
   - ./abb-cvc/ks.yaml
   - ./blackbox-exporter/ks.yaml
+  - ./gatus/ks.yaml
   - ./grafana/ks.yaml
   - ./influxdb/ks.yaml
   - ./kube-prometheus-stack/ks.yaml

--- a/kubernetes/apps/security/authelia/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authelia/app/helmrelease.yaml
@@ -114,6 +114,8 @@ spec:
             port: 8080
     route:
       app:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - auth.${SECRET_PUBLIC_DOMAIN}
         parentRefs:


### PR DESCRIPTION
## Summary
- add an internal-only Gatus deployment in `observability` for external route health
- use `gatus-sidecar` to discover explicitly annotated `envoy-external` HTTPRoutes
- add Prometheus alerting for failing generated route checks and suppress it during WAN outages

## Validation
- `kustomize build kubernetes/apps/{network,security,automation,default,media,observability}`
- `kustomize build kubernetes/apps/observability/gatus/app`
- `helm template gatus oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.0 --namespace observability --values /tmp/gatus-values.yaml`