### PR TITLE
feat(observability): add critical internal route monitoring

### DIFF
--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -98,6 +98,8 @@ spec:
             port: 1984
     route:
       main:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - "frigate.${SECRET_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/automation/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/go2rtc/app/helmrelease.yaml
@@ -98,6 +98,8 @@ spec:
             protocol: UDP
     route:
       main:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - "go2rtc.${SECRET_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -130,6 +130,8 @@ spec:
 
     route:
       app:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - "hass.${SECRET_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/automation/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/zigbee2mqtt/app/helmrelease.yaml
@@ -89,6 +89,8 @@ spec:
             port: *port
     route:
       main:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - zigbee.${SECRET_DOMAIN}
         parentRefs:

--- a/kubernetes/apps/network/adguard/app/helmrelease.yaml
+++ b/kubernetes/apps/network/adguard/app/helmrelease.yaml
@@ -68,6 +68,8 @@ spec:
 
     route:
       main:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - "adguard.${SECRET_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -48,6 +48,13 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: envoy-internal
+  annotations:
+    gatus.home-operations.com/endpoint: |-
+      group: internal
+      interval: 1m
+      conditions:
+        - "[STATUS] < 400"
+        - "[RESPONSE_TIME] < 5000"
 spec:
   gatewayClassName: envoy
   infrastructure:

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -43,7 +43,6 @@ spec:
               tag: 0.0.14@sha256:b77e0a1267708a555640b81dd8a9baa2a197c2f34647dc4ac053eb812d4b31cc
             args:
               - --enable-httproute
-              - --gateway-name=envoy-external
               - --output=/config/gatus-sidecar.yaml
               - --default-interval=1m
             restartPolicy: Always

--- a/kubernetes/apps/observability/gatus/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/gatus/app/prometheusrule.yaml
@@ -19,3 +19,12 @@ spec:
           annotations:
             summary: "Public route {{ $labels.name }} is failing its Gatus check"
             description: "Gatus has not received a fast <400 response from {{ $labels.name }} for 3 minutes. Check Cloudflare Tunnel, external Envoy, and the backend Service endpoints."
+
+        - alert: GatusInternalEndpointDown
+          expr: gatus_results_endpoint_success{group="internal"} == 0
+          for: 3m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Internal route {{ $labels.name }} is failing its Gatus check"
+            description: "Gatus has not received a fast <400 response from {{ $labels.name }} for 3 minutes. Check internal DNS, internal Envoy, and the backend Service endpoints."

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
@@ -3,6 +3,8 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: alertmanager
+  annotations:
+    gatus.home-operations.com/enabled: "true"
 spec:
   parentRefs:
     - name: envoy-internal
@@ -18,6 +20,8 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: prometheus
+  annotations:
+    gatus.home-operations.com/enabled: "true"
 spec:
   parentRefs:
     - name: envoy-internal

--- a/kubernetes/apps/security/authelia/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authelia/app/helmrelease.yaml
@@ -122,6 +122,8 @@ spec:
           - name: envoy-external
             namespace: network
       internal:
+        annotations:
+          gatus.home-operations.com/enabled: "true"
         hostnames:
           - auth.${SECRET_DOMAIN}
         parentRefs:


### PR DESCRIPTION
## Summary
- extend the new Gatus route monitor to process annotated internal HTTPRoutes as well as external ones
- add shared `envoy-internal` Gatus defaults under the neutral `internal` group
- annotate critical internal routes for monitoring:
  - Home Assistant
  - Frigate
  - go2rtc
  - Zigbee2MQTT
  - AdGuard UI
  - Authelia internal UI
  - Prometheus
  - Alertmanager
- add a `GatusInternalEndpointDown` Prometheus alert

## Notes
- This intentionally does not enable all internal routes; non-critical apps such as media/downloaders/docs/tools are left out.
- MQTT and other non-HTTP services are not covered here because this change is scoped to HTTPRoutes.

## Validation
- `kustomize build kubernetes/apps/automation`
- `kustomize build kubernetes/apps/observability/gatus/app`
- `helm template gatus oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.0 --namespace observability --values /tmp/gatus-values.yaml`
- `rg -n "petrovic-cloud|Petrovic Cloud" .` returned no matches
