### PR TITLE
fix(observability): monitor readeck external route via api

### DIFF
--- a/kubernetes/apps/default/readeck/app/helmrelease.yaml
+++ b/kubernetes/apps/default/readeck/app/helmrelease.yaml
@@ -73,6 +73,13 @@ spec:
       app:
         annotations:
           gatus.home-operations.com/enabled: "true"
+          gatus.home-operations.com/endpoint: |-
+            url: https://readeck.${SECRET_PUBLIC_DOMAIN}/api
+            client:
+              ignore-redirect: true
+            conditions:
+              - "[STATUS] < 400"
+              - "[RESPONSE_TIME] < 5000"
         hostnames:
           - "readeck.${SECRET_PUBLIC_DOMAIN}"
         parentRefs:


### PR DESCRIPTION
## Summary
- Override the readeck external Gatus endpoint to check `/api` instead of the Authelia-protected root path.
- Keep the inherited external route health conditions (`[STATUS] < 400`, response time under 5s) and disable redirect following for the check.

## Validation
- `python3` YAML parse for `kubernetes/apps/default/readeck/app/helmrelease.yaml`
- `kubectl kustomize kubernetes/apps/default/readeck/app`
- `curl --max-redirs 0 https://readeck.petrovic.cloud/api` returns `303` quickly, satisfying `<400`
