### PR TITLE
fix(observability): accept authenticated route responses in Gatus

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -53,7 +53,7 @@ metadata:
       group: internal
       interval: 1m
       conditions:
-        - "[STATUS] < 400"
+        - "[STATUS] < 500"
         - "[RESPONSE_TIME] < 5000"
 spec:
   gatewayClassName: envoy
@@ -91,7 +91,7 @@ metadata:
       group: external
       interval: 1m
       conditions:
-        - "[STATUS] < 400"
+        - "[STATUS] < 500"
         - "[RESPONSE_TIME] < 5000"
 spec:
   gatewayClassName: envoy

--- a/kubernetes/apps/observability/gatus/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/gatus/app/prometheusrule.yaml
@@ -18,7 +18,7 @@ spec:
             severity: critical
           annotations:
             summary: "Public route {{ $labels.name }} is failing its Gatus check"
-            description: "Gatus has not received a fast <400 response from {{ $labels.name }} for 3 minutes. Check Cloudflare Tunnel, external Envoy, and the backend Service endpoints."
+            description: "Gatus has not received a fast <500 response from {{ $labels.name }} for 3 minutes. Check Cloudflare Tunnel, external Envoy, and the backend Service endpoints."
 
         - alert: GatusInternalEndpointDown
           expr: gatus_results_endpoint_success{group="internal"} == 0
@@ -27,4 +27,4 @@ spec:
             severity: critical
           annotations:
             summary: "Internal route {{ $labels.name }} is failing its Gatus check"
-            description: "Gatus has not received a fast <400 response from {{ $labels.name }} for 3 minutes. Check internal DNS, internal Envoy, and the backend Service endpoints."
+            description: "Gatus has not received a fast <500 response from {{ $labels.name }} for 3 minutes. Check internal DNS, internal Envoy, and the backend Service endpoints."


### PR DESCRIPTION
## Summary
- treat any fast non-5xx response as healthy for route-level Gatus checks
- avoids false positives for authenticated routes returning 401/403 while still catching stale Envoy endpoints and backend failures returning 5xx/timeouts
- updates alert descriptions to match the route-health semantics

## Follow-up from rollout
Gatus discovered the expected 15 endpoints, but authenticated routes such as Readeck, AdGuard, and Frigate returned 401 and failed the previous `<400` condition. Stale endpoint failures from Envoy surface as 503/timeouts, so `<500` is the better synthetic route-health condition.

## Validation
- `kustomize build kubernetes/apps/{network,observability}`
- `kustomize build kubernetes/apps/observability/gatus/app`
- `helm template gatus oci://ghcr.io/bjw-s-labs/helm/app-template --version 5.0.0 --namespace observability --values /tmp/gatus-values.yaml`
- `rg -n "petrovic-cloud|Petrovic Cloud" .` returned no matches
