### PR TITLE
feat(network): make AdGuard DNS highly available

### DIFF
--- a/.pi/todos/f3dd63bb.md
+++ b/.pi/todos/f3dd63bb.md
@@ -101,3 +101,71 @@ Adopt the Gabe-style active/active AdGuard pattern:
 
 - Keep current AdGuard PVC and manifests recoverable until validation completes.
 - If sync/StatefulSet migration fails, revert to the current single-replica HelmRelease and reattach the original `network/adguard` PVC.
+
+## Progress — 2026-05-15 08:22 AEST
+
+Implemented the GitOps manifest changes for the active/active design:
+
+- Converted `network/adguard` to a 2-replica `StatefulSet` with per-ordinal RWO `volumeClaimTemplates`.
+- The new per-pod PVCs clone from the existing `network/adguard` PVC on first creation so the origin and replica start with the current UI-managed config.
+- Added topology spread plus a PDB so the two AdGuard pods are scheduled on different nodes and at least one remains available during voluntary disruptions.
+- Kept `adguard-dns` at `10.0.88.53` and selecting both AdGuard pods for DNS/DoH/DoT.
+- Pinned the admin UI service/HTTPRoute to `adguard-0` via `apps.kubernetes.io/pod-index: "0"`.
+- Added a headless service for stable pod DNS (`adguard-0/1.adguard-headless.network.svc.cluster.local`).
+- Added `ghcr.io/bakito/adguardhome-sync:v0.9.0` as a separate controller to sync origin `adguard-0` to replica `adguard-1`.
+- Added `ExternalSecret/adguard-sync` for sync credentials from 1Password item `adguard` fields `username` and `password`.
+
+Validation performed locally/read-only:
+
+- `helm template` for the app-template values succeeded.
+- `flux build kustomization adguard -n network --dry-run` succeeded.
+- `kubectl apply --dry-run=server` succeeded for the Flux-built resources and the rendered Helm resources (with dummy substitutions and Gateway API v1 capabilities).
+- Baseline checks before rollout: gateway DNS, AdGuard UDP DNS, AdGuard TCP DNS, TCP/443, and TCP/853 were reachable.
+
+Rollout is not complete yet. Before merging/applying, verify/create the 1Password item `adguard` with fields `username` and `password`, and put the operator MacBook into the safe gateway-DNS posture described above.
+
+## PR
+
+- Draft PR: https://github.com/adampetrovic/home-ops/pull/2675
+
+## Progress — 2026-05-15 08:34 AEST
+
+User confirmed the 1Password Connect-visible item `adguard` now exists with `username` and `password` fields for the native AdGuard Home credentials.
+
+CI on draft PR #2675 is green:
+
+- Flux Local - Test: pass
+- Flux Local - Diff (HelmRelease): pass
+- Flux Local - Diff (Kustomization): pass
+
+Remaining before rollout/merge: put the operator MacBook in the safe gateway-DNS posture and explicitly approve applying the DNS change.
+
+## Backup — 2026-05-15 08:42 AEST
+
+Created rollback backups before merging/applying the HA AdGuard changes:
+
+1. **VolSync ad-hoc backups**
+   - Ran `task volsync:backup app=adguard ns=network type=all`.
+   - Kopia ReplicationSource `network/adguard` completed successfully.
+   - R2 ReplicationSource `network/adguard-r2` completed successfully.
+   - `network/adguard` status shows last manual sync `083821`, last sync time `2026-05-14T22:39:01Z`, result `Successful`, snapshot ID `4af5906039bfa81c5146a638fccafa6e`, root `k86721cfe8c1aa482522b2590c52a0150`.
+   - `network/adguard-r2` status shows last sync time `2026-05-14T22:39:52Z`.
+
+2. **Local private tarball**
+   - Saved current `/opt/adguardhome/conf` and `/opt/adguardhome/work` from the running pod to:
+     - `/Users/adam/.pi/backups/home-ops/adguard/20260515-084001-AEST/adguardhome-conf-work.tar.gz`
+   - Also saved current live Kubernetes objects to:
+     - `/Users/adam/.pi/backups/home-ops/adguard/20260515-084001-AEST/k8s-current-adguard-resources.yaml`
+   - Verified `gzip -t` and `shasum -a 256 -c SHA256SUMS` successfully.
+   - Note: local archive is private and includes AdGuard work data/query logs.
+
+3. **Ceph CSI VolumeSnapshot**
+   - Created `network/adguard-pre-ha-20260515-084152` from PVC `network/adguard`.
+   - Snapshot is `readyToUse=true`, size `5Gi`, content `snapcontent-f3e78e76-9e3c-407c-ad57-515fe103a883`.
+
+Rollback options now available:
+
+- Revert the PR/manifests to the single-pod Deployment and original `network/adguard` PVC.
+- Restore from the VolSync Kopia/R2 backup if PVC data needs to be recreated.
+- Restore a PVC from the CSI `VolumeSnapshot` if a fast in-cluster rollback is needed.
+- As a final fallback, unpack the local private tarball into a recovered AdGuard PVC.

--- a/.pi/todos/f3dd63bb.md
+++ b/.pi/todos/f3dd63bb.md
@@ -11,7 +11,8 @@
     "reliability"
   ],
   "status": "open",
-  "created_at": "2026-05-14T21:52:41.081Z"
+  "created_at": "2026-05-14T21:52:41.081Z",
+  "assigned_to_session": "019e2887-5eb9-708d-921f-e0943f302116"
 }
 
 # Make AdGuard DNS/DoH highly available

--- a/.pi/todos/f3dd63bb.md
+++ b/.pi/todos/f3dd63bb.md
@@ -1,0 +1,102 @@
+{
+  "id": "f3dd63bb",
+  "title": "Make AdGuard DNS/DoH highly available",
+  "tags": [
+    "home-ops",
+    "network",
+    "adguard",
+    "dns",
+    "doh",
+    "ha",
+    "reliability"
+  ],
+  "status": "open",
+  "created_at": "2026-05-14T21:52:41.081Z"
+}
+
+# Make AdGuard DNS/DoH highly available
+
+## Context
+
+During the `k8s-node-3` hard hang on 2026-05-15 AEST, AdGuard could not fail over cleanly. Kubernetes created a replacement pod on another node, but the single `network/adguard` RWO Ceph block PVC remained attached to the unreachable node, causing `Multi-Attach` and leaving DNS/DoH unavailable until the node was power-cycled.
+
+MacBooks using the DNSSettings profile were pinned to `https://dns.${SECRET_DOMAIN}/dns-query/adam-laptop` via `10.0.88.53`; `AllowFailover=true` did not fail over quickly enough because the managed DoH resolver remained sticky. Disabling the profile made DHCP DNS work immediately.
+
+## Goal
+
+Keep the existing stable DNS/DoH endpoint (`dns.${SECRET_DOMAIN}`, `10.0.88.53`) but remove AdGuard's single-PVC single-pod failure mode so DNS and native macOS DoH survive a hard node failure.
+
+## Proposed design
+
+Adopt the Gabe-style active/active AdGuard pattern:
+
+1. Convert AdGuard from a single-replica Deployment with one shared PVC to a StatefulSet with `replicas: 2`.
+2. Give each AdGuard pod its own RWO PVC via StatefulSet `volumeClaimTemplates`.
+3. Add pod anti-affinity/topology spread so the two replicas land on different nodes.
+4. Run `ghcr.io/bakito/adguardhome-sync` as a separate controller to sync configuration from origin (`adguard-0`) to replica (`adguard-1`).
+5. Keep a shared `adguard-dns` LoadBalancer at `10.0.88.53` selecting both AdGuard pods for DNS/DoH/DoT.
+6. Expose the admin UI primarily to the origin pod, with an optional replica UI route for troubleshooting.
+7. Keep both pods serving the same TLS certificate/hostname for `dns.${SECRET_DOMAIN}` so the existing macOS DoH profile can continue using one `ServerURL` and `ServerAddresses: [10.0.88.53]`.
+
+## Implementation notes
+
+- Current manifest: `kubernetes/apps/network/adguard/app/helmrelease.yaml`
+- Current PVC: `network/adguard`, `ceph-block`, RWO, 5Gi
+- Current service IP: `10.0.88.53`
+- Reference patterns:
+  - Stateless/config-in-Git approach: `ahinko/home-ops` AdGuard Home
+  - Stateful origin/replica + `adguardhome-sync`: `gabe565/home-ops` AdGuard Home
+- `adguardhome-sync` needs credentials for both AdGuard instances. Store them via ExternalSecret/1Password; do not commit plaintext.
+- Decide whether to preserve current query logs/stats or treat them as per-replica/non-critical.
+- Consider whether AdGuard config should remain UI-managed + synced, or move toward Git-declared config later.
+
+## Migration plan
+
+1. Export/backup current AdGuard config from the existing PVC/UI.
+2. Put the operator MacBook into a safe test posture before changing cluster DNS:
+   - Disable the DNSSettings/DoH profile temporarily.
+   - Pin the MacBook's active network DNS to the gateway (`10.0.0.1`) so day-to-day connectivity does not depend on AdGuard during rollout.
+   - Use explicit test commands against AdGuard (`@10.0.88.53`) instead of relying on the system resolver while validating failover.
+3. Baseline current behaviour before changing manifests:
+   - `dig @10.0.0.1 example.com` — confirm gateway DNS works independently.
+   - `dig @10.0.88.53 example.com` — confirm AdGuard UDP DNS works.
+   - `dig +tcp @10.0.88.53 example.com` — confirm AdGuard TCP DNS works.
+   - DoH transport smoke test against the VIP, e.g. `curl --resolve 'dns.${SECRET_DOMAIN}:443:10.0.88.53' -sS -o /dev/null -w '%{http_code}\n' 'https://dns.${SECRET_DOMAIN}/dns-query/adam-laptop'`; a non-timeout HTTP response proves TLS/HTTP reaches the service, but this is not a full DNS answer test.
+   - If a DoH-capable CLI is available (`kdig`, `dnslookup`, `doggo`, etc.), use it to perform a real DoH query through `10.0.88.53` with SNI/Host `dns.${SECRET_DOMAIN}`.
+4. Create new StatefulSet-backed configuration with two PVCs while preserving the existing `10.0.88.53` service name/IP.
+5. Bootstrap origin from the current config.
+6. Enable `adguardhome-sync` and verify replica auto-setup + sync.
+7. Verify both pods answer:
+   - UDP/TCP 53
+   - DoH on `https://dns.${SECRET_DOMAIN}/dns-query/...`
+   - DoT on 853 if still required
+8. Verify the shared `adguard-dns` Service has two ready endpoints and no endpoint points at a NotReady pod.
+9. Failover test with the MacBook still pinned to gateway DNS:
+   - Identify which node hosts each AdGuard pod.
+   - Run a loop from the MacBook such as `while true; do date; dig +time=1 +tries=1 @10.0.88.53 example.com; sleep 1; done`.
+   - In a controlled maintenance window, remove one AdGuard backend at a time (pod-level first, then node-level if needed) and confirm `10.0.88.53` continues resolving through the surviving backend.
+   - Repeat for UDP and TCP DNS.
+   - Separately smoke-test DoH transport during each backend failure.
+10. Only after explicit service-level failover passes, re-enable the macOS DNSSettings/DoH profile and validate with macOS system resolver paths, not only `dig`:
+    - `scutil --dns` — confirm the managed resolver is active.
+    - `dscacheutil -q host -a name example.com` — exercises the macOS resolver stack.
+    - Browser/curl test to normal websites.
+    - Then repeat a controlled single-pod AdGuard failure and confirm the MacBook does not require manually disabling the profile.
+11. Remove or archive the old single shared PVC only after the new setup is stable and backups exist.
+
+## Acceptance criteria
+
+- Two AdGuard pods are Running on different nodes.
+- Each pod has an independent PVC.
+- `adguardhome-sync` reports successful sync from origin to replica.
+- `adguard-dns` LoadBalancer remains `10.0.88.53` and has two ready endpoints.
+- DNS/DoH resolution continues when either AdGuard pod is unavailable.
+- A hard failure of one node does not block the surviving AdGuard pod on RWO multi-attach.
+- During rollout, the operator MacBook remains pinned to gateway DNS (`10.0.0.1`) until explicit `dig`/DoH tests against AdGuard pass.
+- `dig @10.0.88.53` and `dig +tcp @10.0.88.53` continue succeeding during single-AdGuard-pod failure.
+- MacBook DNSSettings profile continues to work without manual disablement during single-AdGuard-pod failure.
+
+## Rollback
+
+- Keep current AdGuard PVC and manifests recoverable until validation completes.
+- If sync/StatefulSet migration fails, revert to the current single-replica HelmRelease and reattach the original `network/adguard` PVC.

--- a/kubernetes/apps/network/adguard/app/externalsecret.yaml
+++ b/kubernetes/apps/network/adguard/app/externalsecret.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: adguard-sync
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: adguard-sync-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        ORIGIN_USERNAME: "{{ .ADGUARD_USERNAME }}"
+        ORIGIN_PASSWORD: "{{ .ADGUARD_PASSWORD }}"
+        REPLICA1_USERNAME: "{{ .ADGUARD_USERNAME }}"
+        REPLICA1_PASSWORD: "{{ .ADGUARD_PASSWORD }}"
+  data:
+    - secretKey: ADGUARD_USERNAME
+      remoteRef:
+        key: adguard
+        property: username
+    - secretKey: ADGUARD_PASSWORD
+      remoteRef:
+        key: adguard
+        property: password

--- a/kubernetes/apps/network/adguard/app/helmrelease.yaml
+++ b/kubernetes/apps/network/adguard/app/helmrelease.yaml
@@ -23,8 +23,45 @@ spec:
   values:
     controllers:
       adguard:
+        type: statefulset
+        replicas: 2
+        strategy: RollingUpdate
         annotations:
           secret.reloader.stakater.com/reload: tls-adguard
+        podDisruptionBudget:
+          minAvailable: 1
+        pod:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/controller: adguard
+                  app.kubernetes.io/name: *app
+        statefulset:
+          podManagementPolicy: Parallel
+          serviceName:
+            identifier: headless
+          persistentVolumeClaimRetentionPolicy:
+            whenDeleted: Retain
+            whenScaled: Retain
+          volumeClaimTemplates:
+            - name: data
+              storageClass: ceph-block
+              accessMode: ReadWriteOnce
+              size: 5Gi
+              # Clone the current single-pod PVC into each StatefulSet ordinal
+              # on first creation. Keep the old `adguard` PVC around for rollback
+              # until the active/active setup is validated.
+              dataSource:
+                kind: PersistentVolumeClaim
+                name: adguard
+              globalMounts:
+                - path: /opt/adguardhome/conf
+                  subPath: conf
+                - path: /opt/adguardhome/work
+                  subPath: work
         containers:
           app:
             image:
@@ -33,16 +70,88 @@ spec:
             env:
               TZ: "${TZ}"
             probes:
-              liveness: &probe
-                type: HTTP
-                path: /login.html
-              readiness: *probe
-              startup: *probe
+              liveness:
+                enabled: false
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 443
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              startup:
+                enabled: false
+
+      sync:
+        annotations:
+          secret.reloader.stakater.com/reload: adguard-sync-secret
+        containers:
+          app:
+            image:
+              repository: ghcr.io/bakito/adguardhome-sync
+              tag: v0.9.0@sha256:a4e63e705c5602b7bdd5a9554615a78125521273a7aa5da5831517780a06aee4
+            args: ["run"]
+            env:
+              API_METRICS_ENABLED: "true"
+              API_PORT: &syncPort 8080
+              CONTINUE_ON_ERROR: "false"
+              CRON: "*/15 * * * *"
+              FEATURES_DHCP_SERVER_CONFIG: "false"
+              FEATURES_DHCP_STATIC_LEASES: "false"
+              FEATURES_PROTECTION_STATUS: "true"
+              FEATURES_TLS_CONFIG: "true"
+              HTTP_CLIENT_TIMEOUT: 10s
+              LOG_FORMAT: json
+              LOG_LEVEL: info
+              ORIGIN_URL: http://adguard-0.adguard-headless.network.svc.cluster.local
+              REPLICA1_URL: http://adguard-1.adguard-headless.network.svc.cluster.local
+              RUN_ON_START: "true"
+              TZ: "${TZ}"
+            envFrom:
+              - secretRef:
+                  name: adguard-sync-secret
+            probes:
+              liveness: &syncProbe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *syncPort
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *syncProbe
+              startup:
+                enabled: false
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            seccompProfile:
+              type: RuntimeDefault
 
     service:
       app:
         forceRename: *app
         controller: adguard
+        extraSelectorLabels:
+          apps.kubernetes.io/pod-index: "0"
         ports:
           http:
             port: 80
@@ -65,6 +174,31 @@ spec:
           tls-tcp:
             port: 853
             protocol: TCP
+      headless:
+        controller: adguard
+        clusterIP: None
+        publishNotReadyAddresses: true
+        ports:
+          http:
+            port: 80
+          setup:
+            port: 3000
+      sync:
+        controller: sync
+        ports:
+          http:
+            port: *syncPort
+
+    serviceMonitor:
+      sync:
+        enabled: true
+        serviceName: adguard-sync
+        endpoints:
+          - port: http
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s
 
     route:
       main:
@@ -80,24 +214,12 @@ spec:
               - identifier: app
                 port: http
     persistence:
-      config:
-        enabled: true
-        existingClaim: adguard
-        globalMounts:
-          - path: /opt/adguardhome/conf
-            subPath: conf
-      work:
-        enabled: true
-        storageClass: ceph-block
-        accessMode: ReadWriteOnce
-        size: 5Gi
-        globalMounts:
-          - path: /opt/adguardhome/work
-            subPath: work
       tls:
         enabled: true
         type: secret
         name: tls-adguard
-        globalMounts:
-          - path: /opt/adguardhome/ssl/certs/
-            readOnly: true
+        advancedMounts:
+          adguard:
+            app:
+              - path: /opt/adguardhome/ssl/certs/
+                readOnly: true

--- a/kubernetes/apps/network/adguard/app/kustomization.yaml
+++ b/kubernetes/apps/network/adguard/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: network
 resources:
   - ./certificate.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
 components:
   - ../../../../components/authelia-proxy


### PR DESCRIPTION
## Summary
- Convert AdGuard Home from a single Deployment/shared PVC to a 2-replica StatefulSet with per-pod RWO PVCs cloned from the existing `network/adguard` PVC on first creation.
- Keep `adguard-dns` on `10.0.88.53` while selecting both AdGuard pods for DNS/DoH/DoT.
- Pin the admin UI route to `adguard-0`, add a headless service for stable pod DNS, and run `adguardhome-sync` to copy config from `adguard-0` to `adguard-1`.
- Add ExternalSecret wiring for sync credentials from 1Password item `adguard` (`username` / `password`).

## Pre-merge backups
- Ran `task volsync:backup app=adguard ns=network type=all`; Kopia and R2 ReplicationSources completed successfully.
- Saved a private local archive of current `/opt/adguardhome/conf` and `/opt/adguardhome/work` under `~/.pi/backups/home-ops/adguard/20260515-084001-AEST/` and verified checksums.
- Created Ceph CSI VolumeSnapshot `network/adguard-pre-ha-20260515-084152` from PVC `network/adguard`; it is `readyToUse=true`.

## Validation
- `helm template` for the app-template values succeeded.
- `flux build kustomization adguard -n network --path ./kubernetes/apps/network/adguard/app --kustomization-file ./kubernetes/apps/network/adguard/ks.yaml --dry-run`
- `kubectl apply --dry-run=server -f /tmp/flux-build-adguard.yaml`
- Rendered Helm resources with dummy substitutions + Gateway API v1 capabilities and validated them with `kubectl apply --dry-run=server`.
- Baseline checks before rollout: gateway DNS, AdGuard UDP DNS, AdGuard TCP DNS, TCP/443, and TCP/853 were reachable.
- PR CI is green: Flux Local Test and both Flux Local Diff jobs pass.

## Rollout cautions
- User confirmed the 1Password item `adguard` now exists with `username` and `password` fields for native AdGuard Home credentials.
- Before merging/applying, put the operator MacBook into the safe gateway-DNS posture from TODO-f3dd63bb.
- The new StatefulSet PVCs clone the current `network/adguard` PVC on first creation; keep the old PVC and CSI snapshot for rollback until service-level failover has been validated.
