### PR TITLE
fix(automation): restore batterywise logo icon

### DIFF
--- a/kubernetes/apps/automation/batterywise/app/src/web/index.html
+++ b/kubernetes/apps/automation/batterywise/app/src/web/index.html
@@ -11,7 +11,14 @@
   <main class="page">
     <header class="app-header">
       <div>
-        <h1>BatteryWise</h1>
+        <h1 class="brand">
+          <svg class="brand-icon" viewBox="0 0 28 16" aria-hidden="true" focusable="false">
+            <rect x="1.5" y="2.5" width="22" height="11" rx="2.5"></rect>
+            <path d="M24.5 6h2v4h-2"></path>
+            <path d="M8.5 11 11 7.8H8.8L11.8 4 10.8 7h2.4z"></path>
+          </svg>
+          <span>BatteryWise</span>
+        </h1>
         <p>Compare electricity plans using your actual Sigenergy data.</p>
       </div>
       <div class="status" id="dataStatus">

--- a/kubernetes/apps/automation/batterywise/app/src/web/styles.css
+++ b/kubernetes/apps/automation/batterywise/app/src/web/styles.css
@@ -74,6 +74,33 @@ h1 {
   font-weight: 650;
 }
 
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.brand-icon {
+  width: 28px;
+  height: 16px;
+  flex: 0 0 auto;
+  color: var(--green);
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.brand-icon rect {
+  fill: var(--green-soft);
+}
+
+.brand-icon path:last-child {
+  fill: var(--green);
+  stroke: none;
+}
+
 .app-header p,
 .section-title p,
 .helper,


### PR DESCRIPTION
## Summary
- restore the battery icon beside the BatteryWise wordmark
- keep the header compact and consistent with the current single-column UI

## Validation
- node --check kubernetes/apps/automation/batterywise/app/src/web/app.js
- kustomize build kubernetes/apps/automation/batterywise/app
- uvx check-jsonschema --schemafile https://json.schemastore.org/kustomization kubernetes/apps/automation/batterywise/app/kustomization.yaml
