### PR TITLE
fix(automation): bundle timezone data for batterywise

### DIFF
--- a/kubernetes/apps/automation/batterywise/app/src/comparison.go
+++ b/kubernetes/apps/automation/batterywise/app/src/comparison.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"time"
 )
 
 type CompareRequest struct {
@@ -118,7 +117,7 @@ func ComparePlans(data []UsageRecord, req CompareRequest) PlanComparison {
 }
 
 func CalculatePlanCost(data []UsageRecord, plan Plan) PlanCostBreakdown {
-	loc, _ := time.LoadLocation("Australia/Sydney")
+	loc := sydneyLocation()
 	days := buildDaySlices(data, loc)
 	nDays := len(days)
 	if nDays == 0 {
@@ -151,7 +150,7 @@ func CalculatePlanCost(data []UsageRecord, plan Plan) PlanCostBreakdown {
 }
 
 func calculateBatteryDischargeValue(data []UsageRecord, plan Plan) float64 {
-	loc, _ := time.LoadLocation("Australia/Sydney")
+	loc := sydneyLocation()
 	days := buildDaySlices(data, loc)
 	if len(days) == 0 {
 		return 0

--- a/kubernetes/apps/automation/batterywise/app/src/main.go
+++ b/kubernetes/apps/automation/batterywise/app/src/main.go
@@ -379,7 +379,7 @@ func parseCSV(r io.Reader) ([]UsageRecord, error) {
 // ---------------------------------------------------------------------------
 
 func generateSampleData(days int) []UsageRecord {
-	loc, _ := time.LoadLocation("Australia/Sydney")
+	loc := sydneyLocation()
 	start := time.Date(2025, 1, 1, 0, 0, 0, 0, loc)
 	intervalsPerDay := 96
 	var records []UsageRecord

--- a/kubernetes/apps/automation/batterywise/app/src/simulation.go
+++ b/kubernetes/apps/automation/batterywise/app/src/simulation.go
@@ -119,7 +119,7 @@ type SimResult struct {
 // getPriceForHour returns the TOU rate for a given hour. It is retained for
 // callers that only need a representative hourly price.
 func getPriceForHour(plan Plan, hour int) float64 {
-	loc, _ := time.LoadLocation("Australia/Sydney")
+	loc := sydneyLocation()
 	return getPriceAt(plan, time.Date(2026, time.January, 1, hour, 0, 0, 0, loc))
 }
 
@@ -197,7 +197,7 @@ func containsDay(days []string, d string) bool {
 // getPriceAt returns the TOU rate for a timestamp, including optional month
 // and day constraints imported from Energy Made Easy.
 func getPriceAt(plan Plan, ts time.Time) float64 {
-	loc, _ := time.LoadLocation("Australia/Sydney")
+	loc := sydneyLocation()
 	lt := ts.In(loc)
 	minute := lt.Hour()*60 + lt.Minute()
 	month := int(lt.Month())
@@ -261,7 +261,7 @@ func RunSimulation(data []UsageRecord, scenario Scenario) SimResult {
 		return SimResult{}
 	}
 
-	loc, _ := time.LoadLocation("Australia/Sydney")
+	loc := sydneyLocation()
 	days := buildDaySlices(data, loc)
 	nDays := len(days)
 	if nDays == 0 {

--- a/kubernetes/apps/automation/batterywise/app/src/simulation_test.go
+++ b/kubernetes/apps/automation/batterywise/app/src/simulation_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+func TestRunSimulationUsesSydneyTimezone(t *testing.T) {
+	data := generateSampleData(2)
+	result := RunSimulation(data, Scenario{
+		Name: "test",
+		Plan: Plan{
+			Name:         "Seasonal TOU",
+			SupplyCharge: 1.023,
+			FeedInTariff: 0.028,
+			Windows: []TOUWindow{
+				{StartHour: 0, EndHour: 6, StartMinute: 0, EndMinute: 360, Rate: 0.08, Label: "EV Rate"},
+				{StartHour: 6, EndHour: 15, StartMinute: 360, EndMinute: 900, Rate: 0.4081, Label: "Off-Peak"},
+				{StartHour: 15, EndHour: 21, StartMinute: 900, EndMinute: 1260, Rate: 0.6127, Label: "Peak", Months: []int{1, 2, 3, 6, 7, 8, 11, 12}},
+				{StartHour: 15, EndHour: 21, StartMinute: 900, EndMinute: 1260, Rate: 0.4081, Label: "Off-Peak", Months: []int{4, 5, 9, 10}},
+				{StartHour: 21, EndHour: 24, StartMinute: 1260, EndMinute: 1440, Rate: 0.4081, Label: "Off-Peak"},
+			},
+		},
+		Battery: BatteryConfig{
+			CapacityKWh:    16,
+			UsablePercent:  98,
+			RoundTripEff:   90,
+			MaxChargeKW:    5,
+			MaxDischargeKW: 5,
+			CostDollars:    12000,
+		},
+		Strategy: Strategy{
+			Name:               "test",
+			AlwaysCaptureSolar: true,
+			Rules: []StrategyRule{
+				{Type: "time", Action: "charge", StartHour: 0, EndHour: 6, SOCTarget: 100},
+				{Type: "time", Action: "discharge", StartHour: 15, EndHour: 21, SOCFloor: 0},
+			},
+		},
+	})
+
+	if result.DaysSimulated != 2 {
+		t.Fatalf("DaysSimulated = %d, want 2", result.DaysSimulated)
+	}
+	if len(result.HourlyProfile) != 24 {
+		t.Fatalf("HourlyProfile length = %d, want 24", len(result.HourlyProfile))
+	}
+}

--- a/kubernetes/apps/automation/batterywise/app/src/timezone.go
+++ b/kubernetes/apps/automation/batterywise/app/src/timezone.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"time"
+
+	_ "time/tzdata"
+)
+
+var sydneyTZ = loadSydneyLocation()
+
+func loadSydneyLocation() *time.Location {
+	loc, err := time.LoadLocation("Australia/Sydney")
+	if err != nil {
+		return time.FixedZone("Australia/Sydney", 10*60*60)
+	}
+	return loc
+}
+
+func sydneyLocation() *time.Location {
+	return sydneyTZ
+}


### PR DESCRIPTION
## Summary
- fix BatteryWise simulation panic caused by missing timezone data in the Alpine runtime image
- bundle Go tzdata and centralise Australia/Sydney location loading with a safe fallback
- add a regression test that runs a seasonal TOU simulation using Sydney time

## Root cause
`/api/simulate` panicked with `time: missing Location in call to Time.In` because `time.LoadLocation("Australia/Sydney")` failed inside the minimal runtime image and the nil location was passed into `Time.In`.

## Validation
- gofmt
- go test ./... from kubernetes/apps/automation/batterywise/app/src
- go build -o /tmp/batterywise . from kubernetes/apps/automation/batterywise/app/src
- kustomize build kubernetes/apps/automation/batterywise/app
- uvx check-jsonschema --schemafile https://json.schemastore.org/kustomization kubernetes/apps/automation/batterywise/app/kustomization.yaml
