### PR TITLE
fix(automation): include batterywise timezone source

### DIFF
--- a/kubernetes/apps/automation/batterywise/app/kustomization.yaml
+++ b/kubernetes/apps/automation/batterywise/app/kustomization.yaml
@@ -17,6 +17,7 @@ configMapGenerator:
       - main.go=./src/main.go
       - simulation.go=./src/simulation.go
       - store.go=./src/store.go
+      - timezone.go=./src/timezone.go
   - name: batterywise-web
     files:
       - app.js=./src/web/app.js


### PR DESCRIPTION
## Summary
- include timezone.go in the BatteryWise source ConfigMap so the runtime build sees the Sydney timezone helper

## Validation
- kustomize build kubernetes/apps/automation/batterywise/app
- uvx check-jsonschema --schemafile https://json.schemastore.org/kustomization kubernetes/apps/automation/batterywise/app/kustomization.yaml
