### PR TITLE
fix(automation): resolve batterywise eme plan suffixes

### DIFF
--- a/kubernetes/apps/automation/batterywise/app/src/eme.go
+++ b/kubernetes/apps/automation/batterywise/app/src/eme.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -106,33 +107,19 @@ func handleEMEPlan(w http.ResponseWriter, r *http.Request) {
 }
 
 func fetchEnergyMadeEasyPlan(planID, postcode string) (Plan, error) {
-	u := fmt.Sprintf("https://api.energymadeeasy.gov.au/consumerplan/plan/%s?postcode=%s&withPrices=true", url.PathEscape(planID), url.QueryEscape(postcode))
-	client := http.Client{Timeout: 25 * time.Second}
-	resp, err := client.Get(u)
+	resolvedPlanID, env, err := fetchEnergyMadeEasyPlanEnvelope(planID, postcode)
 	if err != nil {
 		return Plan{}, err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return Plan{}, fmt.Errorf("Energy Made Easy returned HTTP %d", resp.StatusCode)
-	}
 
-	var env emePlanEnvelope
-	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
-		return Plan{}, err
-	}
 	pd := env.Data.PlanData
-	if pd.PlanName == "" && len(pd.Contract) == 0 {
-		return Plan{}, fmt.Errorf("plan %s not found", planID)
-	}
-
 	out := Plan{
 		Name:     pd.PlanName,
 		PlanID:   env.Data.PlanID,
 		Retailer: pd.RetailerName,
 	}
 	if out.PlanID == "" {
-		out.PlanID = planID
+		out.PlanID = resolvedPlanID
 	}
 	if out.Name == "" {
 		out.Name = out.PlanID
@@ -197,6 +184,94 @@ func fetchEnergyMadeEasyPlan(planID, postcode string) (Plan, error) {
 	}
 	out.Unsupported = uniqueStrings(out.Unsupported)
 	return out, nil
+}
+
+type emeHTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e emeHTTPError) Error() string {
+	if strings.TrimSpace(e.Body) == "" {
+		return fmt.Sprintf("Energy Made Easy returned HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("Energy Made Easy returned HTTP %d: %s", e.StatusCode, strings.TrimSpace(e.Body))
+}
+
+func fetchEnergyMadeEasyPlanEnvelope(planID, postcode string) (string, emePlanEnvelope, error) {
+	client := http.Client{Timeout: 25 * time.Second}
+	candidates := emePlanIDCandidates(planID)
+	var lastErr error
+
+	for _, candidate := range candidates {
+		env, err := getEnergyMadeEasyPlanEnvelope(client, candidate, postcode)
+		if err == nil {
+			return candidate, env, nil
+		}
+		lastErr = err
+		if !isEnergyMadeEasyPlanNotFound(err) {
+			return "", emePlanEnvelope{}, err
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("plan %s not found", planID)
+	}
+	return "", emePlanEnvelope{}, fmt.Errorf("Energy Made Easy could not find plan %s for postcode %s", planID, postcode)
+}
+
+func getEnergyMadeEasyPlanEnvelope(client http.Client, planID, postcode string) (emePlanEnvelope, error) {
+	u := fmt.Sprintf("https://api.energymadeeasy.gov.au/consumerplan/plan/%s?postcode=%s&withPrices=true", url.PathEscape(planID), url.QueryEscape(postcode))
+	resp, err := client.Get(u)
+	if err != nil {
+		return emePlanEnvelope{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return emePlanEnvelope{}, emeHTTPError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+
+	var env emePlanEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return emePlanEnvelope{}, err
+	}
+	pd := env.Data.PlanData
+	if pd.PlanName == "" && len(pd.Contract) == 0 {
+		return emePlanEnvelope{}, fmt.Errorf("plan %s not found", planID)
+	}
+	return env, nil
+}
+
+func isEnergyMadeEasyPlanNotFound(err error) bool {
+	httpErr, ok := err.(emeHTTPError)
+	if !ok {
+		return strings.Contains(strings.ToLower(err.Error()), "not found")
+	}
+	return httpErr.StatusCode == http.StatusBadRequest && strings.Contains(strings.ToLower(httpErr.Body), "cannot find plans")
+}
+
+func emePlanIDCandidates(planID string) []string {
+	planID = strings.TrimSpace(planID)
+	if planID == "" {
+		return nil
+	}
+	out := []string{planID}
+	if lastCharIsDigit(planID) {
+		return out
+	}
+	for i := 1; i <= 50; i++ {
+		out = append(out, fmt.Sprintf("%s%d", planID, i))
+	}
+	return out
+}
+
+func lastCharIsDigit(s string) bool {
+	if s == "" {
+		return false
+	}
+	last := s[len(s)-1]
+	return last >= '0' && last <= '9'
 }
 
 func chooseElectricityContract(contracts []emeContract) emeContract {

--- a/kubernetes/apps/automation/batterywise/app/src/eme_test.go
+++ b/kubernetes/apps/automation/batterywise/app/src/eme_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestEMEPlanIDCandidatesAddsNumberedVariantsForBaseID(t *testing.T) {
+	candidates := emePlanIDCandidates("OVO704447MRE")
+	if len(candidates) != 51 {
+		t.Fatalf("len(candidates) = %d, want 51", len(candidates))
+	}
+	if candidates[0] != "OVO704447MRE" {
+		t.Fatalf("first candidate = %q, want base plan ID", candidates[0])
+	}
+	if candidates[20] != "OVO704447MRE20" {
+		t.Fatalf("candidate 20 = %q, want OVO704447MRE20", candidates[20])
+	}
+}
+
+func TestEMEPlanIDCandidatesDoNotAppendToResolvedID(t *testing.T) {
+	candidates := emePlanIDCandidates("OVO704447MRE20")
+	if len(candidates) != 1 {
+		t.Fatalf("len(candidates) = %d, want 1", len(candidates))
+	}
+	if candidates[0] != "OVO704447MRE20" {
+		t.Fatalf("candidate = %q, want OVO704447MRE20", candidates[0])
+	}
+}

--- a/kubernetes/apps/automation/batterywise/app/src/web/app.js
+++ b/kubernetes/apps/automation/batterywise/app/src/web/app.js
@@ -228,7 +228,9 @@ async function importEMEPlan() {
     renderSeasonSummary();
     clearInlineError('emePlanIdError', 'emePlanId');
     const warnings = state.activePlanMeta.unsupported.length ? ` · Warnings: ${state.activePlanMeta.unsupported.join('; ')}` : '';
-    document.getElementById('emePlanMeta').textContent = `${plan.retailer || 'Retailer'} — ${plan.name || id}${warnings}`;
+    const resolvedID = plan.plan_id || id;
+    const resolvedSuffix = resolvedID !== id ? ` · resolved as ${resolvedID}` : ` · ${resolvedID}`;
+    document.getElementById('emePlanMeta').textContent = `${plan.retailer || 'Retailer'} — ${plan.name || id}${resolvedSuffix}${warnings}`;
     showToast('Imported Energy Made Easy plan', 'success');
   } catch (e) {
     showInlineError('emePlanIdError', 'Plan import error: ' + e.message, 'emePlanId');


### PR DESCRIPTION
## Summary
- make BatteryWise resolve Energy Made Easy base plan IDs that require a numbered variant suffix
- keep exact plan IDs unchanged, but try suffixes 1–50 when EME says the base ID cannot be found
- show the resolved EME plan ID in the import metadata
- add unit coverage for candidate plan ID expansion

## Validation
- node --check kubernetes/apps/automation/batterywise/app/src/web/app.js
- go test ./... from kubernetes/apps/automation/batterywise/app/src
- go build -o /tmp/batterywise . from kubernetes/apps/automation/batterywise/app/src
- kustomize build kubernetes/apps/automation/batterywise/app
- uvx check-jsonschema --schemafile https://json.schemastore.org/kustomization kubernetes/apps/automation/batterywise/app/kustomization.yaml

## Manual check
- Direct EME API rejects `OVO704447MRE` for postcode `2213`
- Direct EME API resolves `OVO704447MRE20` for postcode `2213`
