### PR TITLE
docs: split agent instructions into focused references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,511 +1,81 @@
 # AGENTS.md
 
-> Instructions for AI coding agents working in this repository.
-
-## Repository Overview
-
-This is a **home-ops GitOps repository** managing a Kubernetes cluster running on Talos Linux. All infrastructure and applications are declaratively defined and automatically deployed by Flux CD. The cluster consists of 5 bare-metal nodes (3 control plane + 2 workers) running Talos Linux with Cilium CNI.
-
-**Key technologies:** Talos Linux, Kubernetes, Flux CD, Helm, Kustomize, SOPS, 1Password (External Secrets), Rook-Ceph, VolSync, Renovate.
-
-## Version Control
-
-This repository uses **Jujutsu (jj)** as the version control system (with a Git backend). Use `jj` commands instead of `git` for all VCS operations. See the jj skill for details.
-
-When creating jj commit descriptions, include a concise one-line rationale in the commit body where it adds useful context, especially for `fix:` and `chore:` changes. Prefer explaining why the change is being made, not just what changed (for example, `Why: avoid paging on brittle cause-based Talos log patterns`). This is optional for straightforward feature work such as adding a new app.
-
-## Repository Structure
-
-```
-kubernetes/
-├── apps/                    # Application deployments organized by namespace
-│   ├── automation/          # Home Assistant, Frigate, Zigbee2MQTT, etc.
-│   ├── cert-manager/        # TLS certificate management
-│   ├── database/            # CloudNative-PG, Dragonfly, PgAdmin
-│   ├── default/             # General apps (Atuin, Memos, Miniflux, Paperless, etc.)
-│   ├── external-secrets/    # 1Password integration
-│   ├── flux-system/         # Flux operator and instance
-│   ├── kube-system/         # Cilium, Reloader, Descheduler, metrics, etc.
-│   ├── media/               # Plex, Sonarr, Radarr, SABnzbd, etc.
-│   ├── network/             # Envoy Gateway, AdGuard, Cloudflared, ExternalDNS
-│   ├── observability/       # Prometheus, Grafana, Loki, Vector
-│   ├── openebs-system/      # OpenEBS local storage
-│   ├── rook-ceph/           # Distributed storage
-│   ├── security/            # Authelia, LLDAP
-│   ├── storage/             # Garage S3-compatible storage
-│   ├── system-upgrade/      # Tuppr for automated Talos/Kubernetes upgrades
-│   └── volsync-system/      # VolSync operator, Kopia web UI, snapshot controller
-├── components/              # Reusable Kustomize components
-│   ├── common/              # Namespace, SOPS, cluster vars, Helm repos
-│   └── volsync/             # VolSync backup/restore component
-└── flux/
-    └── cluster/             # Top-level Flux Kustomization
-
-talos/                       # Talos Linux configuration
-├── talconfig.yaml           # Node definitions (managed by talhelper)
-├── talenv.yaml              # Talos environment vars
-├── talsecret.yaml           # Talos secrets
-├── clusterconfig/           # Generated node configs (do not edit directly)
-└── patches/                 # Talos machine patches
-    ├── controller/          # Control-plane-specific patches
-    └── global/              # All-node patches
-
-bootstrap/                   # Initial cluster bootstrap
-├── helmfile.yaml            # Bootstrap Helm releases (Cilium → Spegel → cert-manager → ESO → Flux)
-└── resources.yaml.j2        # Bootstrap resources template
-
-scripts/                     # Helper scripts
-├── bootstrap-cluster.sh     # Full cluster bootstrap automation
-└── lib/                     # Script libraries
-
-.taskfiles/                  # Taskfile automation
-├── Kubernetes/              # k8s helper tasks
-├── Talos/                   # Talos upgrade/management tasks
-└── VolSync/                 # Backup/restore tasks
-```
-
-## Application Structure Pattern
-
-Every application follows this consistent structure:
-
-```
-app-name/
-├── ks.yaml                  # Flux Kustomization — entry point for Flux
-└── app/
-    ├── kustomization.yaml   # Kustomize resources list
-    ├── helmrelease.yaml     # HelmRelease (most apps use bjw-s app-template or upstream charts)
-    └── externalsecret.yaml  # ExternalSecret pulling from 1Password (if needed)
-```
-
-### Flux Kustomization (`ks.yaml`)
-
-This is the Flux entry point for each app. Key conventions:
-
-```yaml
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: &app <app-name>           # Use YAML anchors for DRY
-  namespace: &namespace <namespace>
-spec:
-  targetNamespace: *namespace
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  dependsOn: []                    # List upstream dependencies
-  path: ./kubernetes/apps/<namespace>/<app-name>/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  wait: true                       # false if nothing depends on this app
-  interval: 30m
-  retryInterval: 1m
-  timeout: 5m
-```
-
-**For apps with persistent storage (VolSync)**, add the volsync component and postBuild substitution variables:
-
-```yaml
-spec:
-  components:
-    - ../../../../components/volsync
-  postBuild:
-    substitute:
-      APP: *app
-      VOLSYNC_CAPACITY: 10Gi
-      VOLSYNC_KOPIA_SCHEDULE: "12 * * * *"   # Kopia backup schedule (default: "0 * * * *")
-      VOLSYNC_R2_SCHEDULE: "30 3 * * *"      # Cloudflare R2 backup schedule (default: "0 3 * * *")
-```
-
-Both `VOLSYNC_KOPIA_SCHEDULE` and `VOLSYNC_R2_SCHEDULE` can be overridden per-app. Most apps set a custom Kopia minute offset (e.g., `12 * * * *`) to spread backup load across the hour. A `MutatingAdmissionPolicy` injects an additional random 0-30s jitter on top of the configured schedule to prevent thundering herd.
-
-### HelmRelease Conventions
-
-- **All workloads** (Deployments, StatefulSets, CronJobs, DaemonSets) **must** use the **bjw-s app-template** chart via `OCIRepository` named `app-template`. Never create raw Kubernetes manifests (e.g. bare `CronJob`, `Deployment` YAML) — always wrap them in a HelmRelease with app-template. For CronJobs, use `controllers.<name>.type: cronjob` with `cronjob.schedule`, `cronjob.timeZone`, etc.
-- **Never check application source code into this repository alongside deployments.** The home-ops repository should contain Kubernetes/Talos/GitOps configuration only; application code belongs in its own source repository and must be deployed here as a pre-built container image.
-- Do not mount application source from ConfigMaps, build apps at container startup, or use generic language/runtime images (for example `golang`, `node`, `python`) as an in-cluster build/deploy mechanism. Build and publish an immutable image externally, then reference that image by tag and digest in the HelmRelease.
-- Most apps use the **bjw-s app-template** chart via `OCIRepository` named `app-template`
-- Schema reference: `https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json`
-- Always include `install.remediation.retries: -1` and `upgrade.remediation.strategy: rollback`
-- Use YAML anchors (`&app`, `&port`, `*envFrom`) to reduce duplication
-- Container images should include both tag and digest: `tag: v1.0.0@sha256:abc123...`
-- **Never use `docker.io` directly** — use `mirror.gcr.io` as a pull-through mirror instead. For Docker Hub images, replace the `docker.io/` prefix with `mirror.gcr.io/` (e.g., `mirror.gcr.io/cloudflare/cloudflared`). For Docker Official Images (e.g., `nginx`, `redis`), use `mirror.gcr.io/library/<image>`. Renovate's `registryAliases` config maps `mirror.gcr.io` back to `docker.io` for version lookups.
-- Apply security contexts: `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities: {drop: ["ALL"]}`
-- Set `runAsNonRoot: true` in defaultPodOptions where possible
-
-### ExternalSecret Conventions
-
-- All secrets come from **1Password** via a `ClusterSecretStore` named `onepassword-connect`
-- ExternalSecrets extract keys from 1Password items and template them into Kubernetes secrets
-- PostgreSQL apps typically use an `init-db` init container with `ghcr.io/home-operations/postgres-init`
-- Database connection strings follow the pattern: `postgres://<user>:<pass>@postgres-rw.database.svc.cluster.local/<db>`
-
-### Namespace Kustomization
-
-Each namespace directory has a `kustomization.yaml` that:
-1. References the `../../components/common` component (provides namespace, SOPS, cluster vars, Helm repos)
-2. Lists all `ks.yaml` files for apps in that namespace
-
-```yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: <namespace>
-components:
-  - ../../components/common
-resources:
-  - ./app-one/ks.yaml
-  - ./app-two/ks.yaml
-```
-
-## Routing Conventions (Gateway API)
-
-Ingress is handled by **Envoy Gateway** using the Kubernetes **Gateway API** — there are no legacy `Ingress` resources. Two `Gateway` resources are defined in the `network` namespace:
-
-- **`envoy-internal`** (`10.0.88.200`): For apps accessible only within the local network. Uses `${SECRET_DOMAIN}`.
-- **`envoy-external`** (`10.0.88.201`): For apps exposed to the internet via **Cloudflare Tunnel**. Uses `${SECRET_PUBLIC_DOMAIN}`.
-
-Both Gateways terminate TLS on port 443 with a wildcard certificate and redirect HTTP→HTTPS automatically.
-
-### App-Template Route Configuration
-
-Most apps use the bjw-s app-template `route:` key, which renders `HTTPRoute` resources:
-
-**Internal-only app** (most common):
-```yaml
-route:
-  app:
-    hostnames:
-      - "app.${SECRET_DOMAIN}"
-    parentRefs:
-      - name: envoy-internal
-        namespace: network
-```
-
-**Externally-exposed app** (via Cloudflare Tunnel):
-```yaml
-route:
-  app:
-    hostnames:
-      - "app.${SECRET_PUBLIC_DOMAIN}"
-    parentRefs:
-      - name: envoy-external
-        namespace: network
-```
-
-**Dual internal + external** (rare):
-```yaml
-route:
-  internal:
-    hostnames:
-      - "app.${SECRET_DOMAIN}"
-    parentRefs:
-      - name: envoy-internal
-        namespace: network
-  external:
-    hostnames:
-      - "app.${SECRET_PUBLIC_DOMAIN}"
-    parentRefs:
-      - name: envoy-external
-        namespace: network
-```
-
-When the default `backendRefs` (auto-wired from the `service:` block) aren't sufficient, explicit rules can be added:
-```yaml
-route:
-  app:
-    hostnames:
-      - "app.${SECRET_DOMAIN}"
-    parentRefs:
-      - name: envoy-internal
-        namespace: network
-    rules:
-      - backendRefs:
-          - identifier: app
-            port: http
-```
-
-### Authelia Authentication (authelia-proxy component)
-
-Apps that need **Authelia SSO/ext-auth** include the `authelia-proxy` Kustomize component in their **app-level `kustomization.yaml`** (not `ks.yaml`):
-
-```yaml
-# app/kustomization.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - ./helmrelease.yaml
-  - ./externalsecret.yaml
-components:
-  - ../../../../components/authelia-proxy
-```
-
-This creates an Envoy `SecurityPolicy` that targets the app's `HTTPRoute` by name (`${APP}`), forwarding auth checks to `authelia.security.svc.cluster.local`. A `ReferenceGrant` in the `security` namespace authorises cross-namespace access — if you add authelia-proxy to an app in a **new namespace**, that namespace must be added to the ReferenceGrant at `kubernetes/apps/security/authelia/app/referencegrant.yaml`.
-
-### Cloudflare Tunnel
-
-External traffic flows: **Internet → Cloudflare → cloudflared pod → `envoy-external` Gateway service → app**. The Cloudflare Tunnel is configured in `kubernetes/apps/network/cloudflared/app/configs/config.yaml` and forwards all `*.${SECRET_PUBLIC_DOMAIN}` traffic to the `envoy-external` service.
-
-## Secrets Management
-
-### SOPS Encryption
-
-- Encrypted files match `*.sops.yaml` pattern
-- Encryption uses **age** keys (key file at `~/.config/sops/age/keys.txt`)
-- Kubernetes secrets encrypt only `data` and `stringData` fields (`encrypted_regex: "^(data|stringData)$"`)
-- Talos secrets encrypt the entire file
-- **Never** commit unencrypted secrets. If you need to create a secret, use an ExternalSecret referencing 1Password instead.
-
-### Cluster Variables
-
-- Cluster-wide variables are stored in `kubernetes/components/common/vars/cluster-secrets.sops.yaml` (encrypted)
-- Variables like `${SECRET_DOMAIN}` are substituted into all Flux Kustomizations via `postBuild.substituteFrom`
-
-## Coding Standards
-
-### YAML Formatting
-
-- **Indent:** 2 spaces (never tabs)
-- **Line endings:** LF
-- **Final newline:** Always include
-- All YAML files should start with `---`
-- Include yaml-language-server schema comments where applicable:
-  ```yaml
-  # yaml-language-server: $schema=https://json.schemastore.org/kustomization
-  ```
-
-### Schema Validation
-
-- When changing YAML/JSON files that declare a schema (for example via a `# yaml-language-server: $schema=...` comment), validate the changed file against that schema before reporting completion.
-- Use `uvx check-jsonschema --schemafile <schema-url> <file>` for direct schema checks when no project-specific validator is available.
-- If schema validation fails, fix the manifest and re-run validation before finishing.
-
-### Shell Scripts
-
-- **Indent:** 4 spaces
-- Use `set -Eeuo pipefail` for strict error handling
-- Use `#!/usr/bin/env bash` shebang
-
-### Naming Conventions
-
-- App names are lowercase, hyphen-separated: `home-assistant`, `paperless-ngx`
-- Kubernetes labels follow: `app.kubernetes.io/name: <app-name>`
-- Flux Kustomization names match app directory names
-- HelmRelease names match app directory names
-
-## Renovate (Automated Dependency Updates)
-
-Renovate runs hourly and manages dependency updates automatically. Key conventions:
-
-- **Container images** include digest pinning: `tag: v1.0.0@sha256:...`
-- **Talos/Kubernetes versions** use annotated comments for Renovate detection:
-  ```yaml
-  # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-  TALOS_VERSION: v1.11.3
-  ```
-- **CRD URLs** in bootstrap scripts use similar annotations
-- Renovate config lives in `.renovaterc.json5` and `.renovate/` directory
-- Semantic commits are enforced: `feat(container)!:`, `fix(helm):`, `chore(container):`
-
-## Task Automation
-
-Run tasks with `task <namespace>:<task>`. Key commands:
-
-```bash
-# Talos operations
-task talos:generate              # Generate Talos node configs
-task talos:apply                 # Apply configs to nodes
-task talos:upgrade node=<ip>     # Upgrade Talos on a node
-task talos:upgrade-rollout       # Rolling upgrade all nodes
-task talos:upgrade-k8s node=<ip> to=<version>  # Upgrade Kubernetes
-task talos:fetch-kubeconfig      # Fetch kubeconfig
-
-# Kubernetes
-task k8s:delete-failed-pods     # Clean up failed/evicted pods
-
-# VolSync backup/restore
-task volsync:list app=<name> ns=<namespace>      # List snapshots
-task volsync:snapshot app=<name> ns=<namespace>   # Create snapshot
-task volsync:restore app=<name> ns=<namespace>    # Restore from snapshot
-task volsync:unlock app=<name> ns=<namespace>     # Unlock restic repo (R2)
-```
-
-## Storage
-
-- **Rook-Ceph** (`ceph-block` StorageClass): Default for most persistent volumes (RWO)
-- **Rook-CephFS**: For RWX volumes
-- **OpenEBS** (`openebs-hostpath`): Local high-performance volumes, used for VolSync R2 cache
-- **NFS**: Synology NAS mounts for media storage and Kopia backup repository (`/volume2/kopia`)
-- **VolSync**: Dual-storage backup strategy:
-  - **Kopia (primary)**: Hourly backups to NFS filesystem repository (uses perfectra1n VolSync fork with Kopia support)
-  - **Restic (secondary)**: Daily backups to Cloudflare R2 for off-site disaster recovery
-  - `MutatingAdmissionPolicy` resources inject NFS mounts and jitter into VolSync mover jobs automatically
-  - `KopiaMaintenance` CRD runs repository maintenance every 12 hours
-  - Kopia web UI available at `kopia.<domain>` for browsing backups
-
-## Network
-
-- **Pod CIDR:** `10.69.0.0/16`
-- **Service CIDR:** `10.96.0.0/16`
-- **LoadBalancer VIP:** `10.0.80.99`
-- **Routed Kubernetes LoadBalancer prefix:** `10.0.88.0/24` (BGP-advertised; Envoy VIPs live here)
-- **Node IPs:** `10.0.80.10-14` (Management VLAN 80)
-- **Trusted VLAN 10:** `10.0.10.0/24` (secondary interfaces for IoT access)
-- CNI is **Cilium** (eBPF-based, deployed without kube-proxy)
-
-### Post-upgrade LoadBalancer/L2 sanity check
-
-After any Talos or Kubernetes rollout (especially Tuppr upgrades), explicitly check north/south `LoadBalancer` services using `externalTrafficPolicy: Local`.
-
-For BGP-advertised services such as `network/envoy-internal` (`10.0.88.200`) and `network/envoy-external` (`10.0.88.201`), ensure UCG BGP next-hops only include nodes with ready local endpoints. A stale or premature next-hop can cause `connection refused` even though pods, Services, HTTPRoutes, and Envoy look healthy.
-
-For any services still using Cilium L2 announcements, ensure the `cilium-l2announce-<namespace>-<service>` lease holder has at least one ready local endpoint for Services with `externalTrafficPolicy: Local`.
-
-Recommended read-only checks:
-
-```bash
-kubectl get svc -A --field-selector spec.type=LoadBalancer
-kubectl get leases -n kube-system | grep cilium-l2announce
-kubectl get endpointslice -n <namespace> -l kubernetes.io/service-name=<service> -o wide
-kubectl get pods -n <namespace> -o wide
-```
-
-For every `cilium-l2announce-<namespace>-<service>` lease whose Service has `externalTrafficPolicy: Local`, ensure the lease holder node has at least one ready local endpoint for that Service. If not, a targeted lease delete can force Cilium to re-elect a holder, but confirm before running `kubectl delete lease ...` because it mutates cluster state.
-
-## Observability
-
-### Talos node logging
-
-Talos service and kernel logs are forwarded to Loki through the existing Vector stack:
-
-```text
-Talos machine.logging / KmsgLogConfig
-  -> tcp://127.0.0.1:6050/ on each node
-  -> hostNetwork vector-agent socket source
-  -> vector-aggregator-talos.observability.svc.cluster.local:6030
-  -> Loki {source="talos"}
-```
-
-Key files:
-
-- `talos/patches/global/machine-logging.yaml` configures Talos service logs and `KmsgLogConfig` kernel logs.
-- `kubernetes/apps/observability/vector/app/agent/resources/vector.yaml` receives/enriches Talos logs and rate-limits them.
-- `kubernetes/apps/observability/vector/app/aggregator/resources/vector.yaml` forwards Talos logs to Loki.
-- `kubernetes/apps/observability/loki/app/helmrelease.yaml` keeps Talos logs at short retention (`48h`) while leaving global retention unchanged.
-- `kubernetes/apps/observability/vector/app/aggregator/talos-logs-dashboard.json` provides the Grafana dashboard.
-- `kubernetes/apps/observability/vector/app/aggregator/lokirule.yaml` contains high-signal Talos Loki alerts.
-
-Operational notes:
-
-- `vector-agent` runs with `hostNetwork: true` and listens only on host loopback `127.0.0.1:6050` for Talos TCP JSON-lines logs.
-- Talos log labels should stay low-cardinality: `source`, `cluster`, `node`, `stream`, `service`, `level`. Do not add labels for message text, sequence numbers, kernel clock, or raw source address.
-- Debug-level Talos logs are filtered in Vector before they are sent to the aggregator/Loki; keep this unless explicitly troubleshooting noisy Talos internals.
-- The per-node Talos Vector throttle is intentionally conservative (`500` events/sec/node). Revisit it after real Talos upgrade/restart noise is observed.
-- Logs emitted before the host-network `vector-agent` is listening can be dropped; this is accepted for now.
-- Do not edit `talos/clusterconfig/` directly. Change Talos patches, run `task talos:generate`, and inspect/apply the generated node configs.
-
-Useful Loki queries:
-
-```logql
-{source="talos", node="k8s-node-1"}
-{source="talos", stream="service", service="kubelet"}
-{source="talos", stream="kernel", level=~"warn|err|error|crit|alert|emerg"}
-sum by (node, stream) (count_over_time({source="talos"}[5m]))
-```
-
-## GitOps Reconciliation
-
-Flux reconciles cluster state from Git automatically. A **GitHub webhook** notifies the Flux Notification Controller on every push to `main`, triggering an immediate reconciliation — there is no need to wait for the default polling interval. This means pushing a fix to a broken HelmRelease will be picked up within seconds, not minutes.
-
-Combined with `install.remediation.retries: -1`, a newly introduced app that fails on first install will keep retrying indefinitely until the configuration is correct. Push a fix → GitHub webhook fires → Flux pulls immediately → Helm retries with the corrected spec.
-
-You can still force a manual reconciliation if needed:
-
-```bash
-flux reconcile ks <app-name> -n flux-system --with-source
-```
-
-## Common Operations for Agents
-
-### Adding a New Application
-
-1. Create the directory structure under `kubernetes/apps/<namespace>/<app-name>/`
-2. Create `ks.yaml` (Flux Kustomization) with appropriate `dependsOn`
-3. Create `app/helmrelease.yaml` using app-template or upstream chart
-4. Create `app/kustomization.yaml` listing all resources
-5. If the app needs a web UI: add a `route:` block in the HelmRelease pointing to `envoy-internal` or `envoy-external`
-6. If the app needs Authelia auth: add the `authelia-proxy` component to `app/kustomization.yaml`
-7. If secrets needed: create `app/externalsecret.yaml` referencing 1Password
-8. If persistent storage needed: add volsync component to `ks.yaml`
-9. Add the `ks.yaml` reference to the namespace's `kustomization.yaml`
-
-### Pull Request CI Checks
-
-CI checks are useful validation but are **not a default merge gate**. Do not wait for PR checks to pass before merging unless the user explicitly asks you to wait. If you do check CI, the key checks are:
-
-- **Flux Local - Test**: Runs `flux-local test` which renders all HelmReleases and Kustomizations with Helm and validates the output. This catches template errors, invalid YAML, and malformed Kubernetes resources.
-- **Flux Local - Diff**: Shows the rendered diff of HelmReleases and Kustomizations vs the main branch. Review this to verify the change produces the expected output.
-
-```bash
-# Optional PR status check
-gh pr checks <pr-number>
-```
-
-If you choose to wait for checks and any check fails, inspect the failure with `gh run view <run-id> --log-failed`, fix the issue, and push again before merging.
-
-### Modifying an Existing Application
-
-- Edit the `helmrelease.yaml` for configuration changes
-- Edit `ks.yaml` for dependency or VolSync changes
-- Flux will automatically detect and apply changes once committed and pushed
-
-### Debugging Applications
-
-```bash
-kubectl get ks -A                          # Check Flux Kustomization status
-kubectl get hr -A                          # Check HelmRelease status
-flux get kustomization --all-namespaces    # Detailed Flux status
-kubectl describe hr <name> -n <namespace>  # HelmRelease details
-kubectl logs -n <namespace> <pod>          # Application logs
-flux reconcile ks <name> --with-source     # Force reconciliation
-```
-
-### Suspending/Resuming Flux
-
-```bash
-flux suspend ks <name> -n flux-system      # Pause reconciliation
-flux resume ks <name> -n flux-system       # Resume reconciliation
-flux suspend hr <name> -n <namespace>      # Pause Helm release
-flux resume hr <name> -n <namespace>       # Resume Helm release
-```
-
-### Post-Merge Cleanup
-
-After a bookmark is merged to `main` (via PR merge or direct push), clean up to avoid stale bookmarks and divergent revisions:
-
-```bash
-# 1. Fetch latest remote state
-jj git fetch
-
-# 2. Delete the merged bookmark locally
-jj bookmark delete <bookmark-name>
-
-# 3. Push the deletion to the remote
-jj git push --deleted
-
-# 4. Move the working copy to main so it's not stranded on an old revision
-jj new main
-```
-
-If multiple bookmarks were merged, delete them all before running `jj git push --deleted` once. Always leave the working copy on or above `main` — never on a stale merged revision.
-
-## Important Warnings
-
-- **Never edit files in `talos/clusterconfig/`** — these are generated by `task talos:generate`
-- **Never commit plaintext secrets** — use ExternalSecrets (1Password) or SOPS encryption
-- **Never modify Flux system resources directly** — changes are reconciled from Git
-- **Be cautious with `prune: true`** — removing a resource from Git will delete it from the cluster
-- **The `*.sops.yaml` files are encrypted** — you cannot read their contents without the age key
-- **Container image tags should always include digests** for reproducibility
-- **Respect `dependsOn` chains** — apps may fail if their dependencies aren't ready
+> Always-loaded instructions for AI coding agents working in this repository.
+
+## How Pi Uses This File
+
+Pi concatenates this file into the startup prompt. Keep it high-signal: critical rules live here, while detailed procedures live under `docs/agent/`. When a task matches one of the read gates below, read the linked doc before editing.
+
+## Repository Snapshot
+
+This is the `home-ops` GitOps repository for a 5-node bare-metal Talos Linux Kubernetes cluster. Flux CD reconciles everything from Git. Key technologies: Talos Linux, Kubernetes, Flux CD, Helm, Kustomize, SOPS, 1Password External Secrets, Rook-Ceph, VolSync, Renovate, Cilium, Envoy Gateway.
+
+## Operating Contract
+
+- Use **Jujutsu (`jj`)** for all version-control operations. Do not use `git` directly in this repo.
+- For `fix:` and `chore:` jj commits, add a concise one-line body explaining *why* where useful, for example `Why: avoid paging on brittle cause-based Talos log patterns`.
+- Never commit plaintext secrets. Use ExternalSecrets backed by 1Password, or SOPS for files that are intentionally encrypted.
+- Never edit `talos/clusterconfig/`; it is generated. Change Talos patches, run `task talos:generate`, then inspect generated output.
+- Never check application source code into this repository alongside deployments. Application code belongs in its own source repo and must be deployed here as a pre-built immutable container image.
+- All workloads must be represented by HelmRelease resources, normally using the `app-template` OCIRepository. Do not add raw Deployments, StatefulSets, DaemonSets, or CronJobs.
+- Container images must include both tag and digest, and Docker Hub images must use `mirror.gcr.io` rather than `docker.io`.
+- Use Gateway API routes only. Do not add legacy `Ingress` resources.
+- Validate changed YAML/JSON files that declare schemas before reporting completion.
+- Preserve `dependsOn` chains and be cautious with `prune: true`; removing resources from Git deletes them from the cluster.
+
+## Required Read Gates
+
+Read the relevant doc before making non-trivial changes:
+
+- Application deployment, HelmRelease, PVC, VolSync, ExternalSecret, or app add/remove: `docs/agent/app-deployments.md`
+- HTTPRoute, Envoy Gateway, Authelia, Cloudflare Tunnel, app exposure: `docs/agent/routing.md`
+- SOPS, 1Password, formatting, schema validation, Renovate conventions: `docs/agent/secrets-standards-renovate.md`
+- PRs, jj workflow, Flux reconciliation, debugging commands, post-merge cleanup: `docs/agent/operations.md`
+- Talos, node upgrades, storage, networking, load balancers, Talos logs, observability platform: `docs/agent/platform.md`
+- Unsure where to start: `docs/agent/README.md`
+
+## Common Repository Layout
+
+- `kubernetes/apps/<namespace>/<app>/` — Flux-managed applications
+- `kubernetes/components/` — reusable Kustomize components, including VolSync and common vars
+- `kubernetes/flux/cluster/` — top-level Flux Kustomization
+- `talos/patches/` — editable Talos patches
+- `talos/clusterconfig/` — generated Talos configs; do not edit
+- `.taskfiles/` — task automation
+
+## Quick App Rules
+
+- App directories use `ks.yaml` plus `app/kustomization.yaml` and `app/helmrelease.yaml`.
+- Persistent apps use the VolSync component and set `APP` plus `VOLSYNC_CAPACITY` substitutions.
+- Secrets come from the `onepassword-connect` ClusterSecretStore via ExternalSecret.
+- PostgreSQL app connection strings use `postgres://<user>:<pass>@postgres-rw.database.svc.cluster.local/<db>`.
+- App names are lowercase hyphenated and match Flux Kustomization and HelmRelease names.
+
+## Quick Routing Rules
+
+- Internal-only apps route through `network/envoy-internal` and `${SECRET_DOMAIN}`.
+- Public apps route through `network/envoy-external` and `${SECRET_PUBLIC_DOMAIN}` via Cloudflare Tunnel.
+- Authelia-protected apps add the `components/authelia-proxy` component to the app-level `kustomization.yaml`.
+- If adding Authelia in a new namespace, update `kubernetes/apps/security/authelia/app/referencegrant.yaml`.
+
+## Quick Formatting and Validation
+
+- YAML uses `---`, 2-space indentation, LF endings, and final newlines.
+- Include schema comments where applicable.
+- Shell scripts use `#!/usr/bin/env bash`, `set -Eeuo pipefail`, and 4-space indentation.
+- For schema-backed YAML/JSON, run `uvx check-jsonschema --schemafile <schema-url> <file>` unless a project-specific validator is more appropriate.
+
+## Quick Operational Notes
+
+- Flux reconciles from `main`; a GitHub webhook triggers reconciliation shortly after pushes.
+- CI checks are useful but not a default merge gate unless the user explicitly asks to wait.
+- After Talos or Kubernetes rollouts, verify LoadBalancer/BGP/L2 endpoint sanity for services using `externalTrafficPolicy: Local`.
+- TODO state changes under `.pi/todos` are major coordination changes; commit and push them using jj.
+
+## High-Priority Warnings
+
+- Never commit unencrypted secrets or derived secret values.
+- Never modify Flux-managed live resources as a substitute for GitOps changes.
+- Never deploy app source from ConfigMaps or build application code at container startup.
+- Never use `docker.io` directly; use `mirror.gcr.io` for Docker Hub images.
+- Never edit generated Talos cluster configs.

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -1,0 +1,15 @@
+# Agent Documentation Index
+
+This directory holds detailed agent procedures that are intentionally kept out of the always-loaded `AGENTS.md` prompt. Pi loads `AGENTS.md` at startup, but it does not automatically load these files. Read the relevant file before doing matching work.
+
+## Read Gates
+
+- `app-deployments.md` — adding, removing, or modifying Kubernetes applications; HelmRelease/app-template conventions; VolSync; ExternalSecrets.
+- `routing.md` — Gateway API, Envoy internal/external routes, Authelia proxy, Cloudflare Tunnel.
+- `secrets-standards-renovate.md` — SOPS, 1Password, YAML/schema validation, Renovate conventions.
+- `operations.md` — jj workflow, Taskfile commands, Flux reconciliation, PR checks, debugging, post-merge cleanup.
+- `platform.md` — repository map, storage, network, post-upgrade LoadBalancer checks, Talos logging/observability.
+
+## Why This Is Split
+
+Pi concatenates `AGENTS.md` into the prompt. Long examples and rarely used procedures compete with critical rules for model attention. Keep `AGENTS.md` concise and imperative; keep detailed workflows here for progressive disclosure.

--- a/docs/agent/app-deployments.md
+++ b/docs/agent/app-deployments.md
@@ -1,0 +1,115 @@
+# Application Deployment Conventions
+
+Read this before adding, removing, or modifying applications under `kubernetes/apps/`.
+
+## Application Structure Pattern
+
+Every application follows this structure:
+
+```text
+app-name/
+├── ks.yaml                  # Flux Kustomization — entry point for Flux
+└── app/
+    ├── kustomization.yaml   # Kustomize resources list
+    ├── helmrelease.yaml     # HelmRelease
+    └── externalsecret.yaml  # ExternalSecret pulling from 1Password, if needed
+```
+
+## Flux Kustomization (`ks.yaml`)
+
+Use this shape for app entrypoints:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app <app-name>
+  namespace: &namespace <namespace>
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn: []
+  path: ./kubernetes/apps/<namespace>/<app-name>/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+```
+
+For apps with persistent storage, add the VolSync component and substitutions:
+
+```yaml
+spec:
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_KOPIA_SCHEDULE: "12 * * * *"
+      VOLSYNC_R2_SCHEDULE: "30 3 * * *"
+```
+
+`VOLSYNC_KOPIA_SCHEDULE` and `VOLSYNC_R2_SCHEDULE` can be overridden per app. Most apps set a custom Kopia minute offset to spread load. A MutatingAdmissionPolicy injects additional jitter.
+
+## HelmRelease Conventions
+
+- All workloads must use HelmRelease, normally with the bjw-s `app-template` chart via the `app-template` OCIRepository.
+- Never add raw Deployments, StatefulSets, DaemonSets, or CronJobs. For CronJobs, use `controllers.<name>.type: cronjob` in app-template.
+- Never check application source code into this repository. Application code belongs in its own source repo and must be deployed here as a pre-built container image.
+- Do not mount application source from ConfigMaps, build apps at container startup, or use generic language/runtime images as in-cluster build mechanisms.
+- Use schema comment: `https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json`.
+- Always include `install.remediation.retries: -1` and `upgrade.remediation.strategy: rollback`.
+- Use YAML anchors (`&app`, `&port`, `*envFrom`) to reduce duplication.
+- Container images must include both tag and digest: `tag: v1.0.0@sha256:abc123...`.
+- Never use `docker.io` directly. Use `mirror.gcr.io` as a pull-through mirror. Docker Official Images use `mirror.gcr.io/library/<image>`.
+- Apply security contexts: `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities: {drop: ["ALL"]}`.
+- Set `runAsNonRoot: true` in `defaultPodOptions` where possible.
+
+## ExternalSecret Conventions
+
+- Secrets come from 1Password via the `ClusterSecretStore` named `onepassword-connect`.
+- ExternalSecrets extract fields from 1Password items and template Kubernetes Secrets.
+- PostgreSQL apps typically use an `init-db` init container with `ghcr.io/home-operations/postgres-init`.
+- Database connection strings follow `postgres://<user>:<pass>@postgres-rw.database.svc.cluster.local/<db>`.
+
+## Namespace Kustomization
+
+Each namespace directory has a `kustomization.yaml` that references `../../components/common` and lists app `ks.yaml` files:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: <namespace>
+components:
+  - ../../components/common
+resources:
+  - ./app-one/ks.yaml
+  - ./app-two/ks.yaml
+```
+
+## Adding a New Application
+
+1. Create `kubernetes/apps/<namespace>/<app-name>/`.
+2. Create `ks.yaml` with appropriate `dependsOn`.
+3. Create `app/helmrelease.yaml` using app-template or an upstream chart.
+4. Create `app/kustomization.yaml` listing all resources.
+5. If the app has a web UI, add a Gateway API `route:` block in the HelmRelease.
+6. If the app needs Authelia auth, add the `authelia-proxy` component to app-level `kustomization.yaml` and check ReferenceGrant needs.
+7. If secrets are needed, create `app/externalsecret.yaml` referencing 1Password.
+8. If persistent storage is needed, add the VolSync component to `ks.yaml`.
+9. Add the app `ks.yaml` to the namespace `kustomization.yaml`.
+
+## Modifying an Existing Application
+
+- Edit `helmrelease.yaml` for app configuration changes.
+- Edit `ks.yaml` for dependencies, wait behavior, pruning, or VolSync substitutions.
+- Preserve app name consistency across directory, Flux Kustomization, HelmRelease, labels, service names, and route names.
+- Flux applies committed changes automatically after the branch is merged or pushed to `main`.

--- a/docs/agent/operations.md
+++ b/docs/agent/operations.md
@@ -1,0 +1,122 @@
+# Agent Operations
+
+Read this before creating commits, opening/updating PRs, running Flux/debug commands, or doing post-merge cleanup.
+
+## Jujutsu Workflow
+
+This repo uses Jujutsu (`jj`) with a Git backend. Use `jj` commands instead of `git`.
+
+Commit descriptions should include a concise one-line rationale in the body where useful, especially for `fix:` and `chore:` changes:
+
+```text
+fix(observability): stop alerting on Talos kernel log patterns
+
+Why: keep paging signals symptom-based instead of brittle cause-based log regexes
+```
+
+Prefer change IDs when referencing revisions. Use `jj diff --git` for reviewable diffs.
+
+## Task Automation
+
+Run tasks with `task <namespace>:<task>`.
+
+Talos operations:
+
+```bash
+task talos:generate
+task talos:apply
+task talos:upgrade node=<ip>
+task talos:upgrade-rollout
+task talos:upgrade-k8s node=<ip> to=<version>
+task talos:fetch-kubeconfig
+```
+
+Kubernetes:
+
+```bash
+task k8s:delete-failed-pods
+```
+
+VolSync:
+
+```bash
+task volsync:list app=<name> ns=<namespace>
+task volsync:snapshot app=<name> ns=<namespace>
+task volsync:restore app=<name> ns=<namespace>
+task volsync:unlock app=<name> ns=<namespace>
+```
+
+## GitOps Reconciliation
+
+Flux reconciles cluster state from Git. A GitHub webhook notifies Flux on every push to `main`, triggering reconciliation quickly.
+
+`install.remediation.retries: -1` means a failing new install keeps retrying until a corrected spec is pushed.
+
+Manual reconciliation when needed:
+
+```bash
+flux reconcile ks <app-name> -n flux-system --with-source
+```
+
+## Pull Request CI Checks
+
+CI checks are useful validation but are not a default merge gate. Do not wait for checks before merging unless the user explicitly asks.
+
+Key checks:
+
+- `Flux Local - Test` renders HelmReleases/Kustomizations and validates output.
+- `Flux Local - Diff` shows rendered diff against main.
+
+Optional status check:
+
+```bash
+gh pr checks <pr-number>
+```
+
+If you choose to wait and checks fail, inspect with:
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+Then fix and push again.
+
+## Debugging Applications
+
+Common read-only checks:
+
+```bash
+kubectl get ks -A
+kubectl get hr -A
+flux get kustomization --all-namespaces
+kubectl describe hr <name> -n <namespace>
+kubectl logs -n <namespace> <pod>
+```
+
+Force reconciliation:
+
+```bash
+flux reconcile ks <name> --with-source
+```
+
+## Suspending and Resuming Flux
+
+```bash
+flux suspend ks <name> -n flux-system
+flux resume ks <name> -n flux-system
+flux suspend hr <name> -n <namespace>
+flux resume hr <name> -n <namespace>
+```
+
+## Post-Merge Cleanup
+
+After a bookmark is merged to `main`, clean up stale bookmarks and move the working copy back to main:
+
+```bash
+jj git fetch
+jj bookmark delete <bookmark-name>
+jj git push --deleted
+jj new main
+```
+
+If multiple bookmarks were merged, delete them all before a single `jj git push --deleted`. Always leave the working copy on or above `main`, never on a stale merged revision.

--- a/docs/agent/platform.md
+++ b/docs/agent/platform.md
@@ -1,0 +1,107 @@
+# Platform Reference
+
+Read this before changing Talos, storage, networking, load balancers, observability, or upgrade-related behavior.
+
+## Repository Structure
+
+```text
+kubernetes/
+├── apps/                    # Application deployments organized by namespace
+├── components/              # Reusable Kustomize components
+│   ├── common/              # Namespace, SOPS, cluster vars, Helm repos
+│   └── volsync/             # VolSync backup/restore component
+└── flux/cluster/            # Top-level Flux Kustomization
+
+talos/
+├── talconfig.yaml           # Node definitions managed by talhelper
+├── talenv.yaml              # Talos environment vars
+├── talsecret.yaml           # Talos secrets
+├── clusterconfig/           # Generated node configs; do not edit directly
+└── patches/                 # Editable Talos machine patches
+
+bootstrap/                   # Initial cluster bootstrap
+scripts/                     # Helper scripts
+.taskfiles/                  # Taskfile automation
+```
+
+## Storage
+
+- Rook-Ceph `ceph-block` is the default StorageClass for most RWO volumes.
+- Rook-CephFS is used for RWX volumes.
+- OpenEBS `openebs-hostpath` provides local high-performance volumes, including VolSync R2 cache.
+- NFS on the Synology NAS is used for media storage and the Kopia repository at `/volume2/kopia`.
+- VolSync uses a dual-storage backup strategy:
+  - Kopia primary backups to NFS.
+  - Restic secondary backups to Cloudflare R2.
+  - MutatingAdmissionPolicies inject NFS mounts and backup jitter into mover jobs.
+  - KopiaMaintenance runs repository maintenance every 12 hours.
+  - Kopia web UI is available at `kopia.<domain>`.
+
+## Network
+
+- Pod CIDR: `10.69.0.0/16`
+- Service CIDR: `10.96.0.0/16`
+- LoadBalancer VIP: `10.0.80.99`
+- Routed Kubernetes LoadBalancer prefix: `10.0.88.0/24` (BGP-advertised; Envoy VIPs live here)
+- Node IPs: `10.0.80.10-14` on Management VLAN 80
+- Trusted VLAN 10: `10.0.10.0/24` for secondary IoT access
+- CNI is Cilium, eBPF-based, without kube-proxy
+
+## Post-Upgrade LoadBalancer/L2 Sanity Check
+
+After any Talos or Kubernetes rollout, especially Tuppr upgrades, explicitly check north/south LoadBalancer services using `externalTrafficPolicy: Local`.
+
+For BGP-advertised services such as `network/envoy-internal` (`10.0.88.200`) and `network/envoy-external` (`10.0.88.201`), ensure UCG BGP next-hops only include nodes with ready local endpoints. A stale next-hop can cause `connection refused` even when pods, Services, HTTPRoutes, and Envoy look healthy.
+
+For Cilium L2 announcements, ensure the `cilium-l2announce-<namespace>-<service>` lease holder has at least one ready local endpoint for Services with `externalTrafficPolicy: Local`.
+
+Read-only checks:
+
+```bash
+kubectl get svc -A --field-selector spec.type=LoadBalancer
+kubectl get leases -n kube-system | grep cilium-l2announce
+kubectl get endpointslice -n <namespace> -l kubernetes.io/service-name=<service> -o wide
+kubectl get pods -n <namespace> -o wide
+```
+
+If a lease holder has no ready local endpoint, a targeted lease delete can force re-election, but confirm before running `kubectl delete lease ...` because it mutates cluster state.
+
+## Talos Node Logging
+
+Talos service and kernel logs flow to Loki through Vector:
+
+```text
+Talos machine.logging / KmsgLogConfig
+  -> tcp://127.0.0.1:6050/ on each node
+  -> hostNetwork vector-agent socket source
+  -> vector-aggregator-talos.observability.svc.cluster.local:6030
+  -> Loki {source="talos"}
+```
+
+Key files:
+
+- `talos/patches/global/machine-logging.yaml`
+- `kubernetes/apps/observability/vector/app/agent/resources/vector.yaml`
+- `kubernetes/apps/observability/vector/app/aggregator/resources/vector.yaml`
+- `kubernetes/apps/observability/loki/app/helmrelease.yaml`
+- `kubernetes/apps/observability/vector/app/aggregator/talos-logs-dashboard.json`
+- `kubernetes/apps/observability/vector/app/aggregator/lokirule.yaml`
+
+Operational notes:
+
+- `vector-agent` uses `hostNetwork: true` and listens only on host loopback `127.0.0.1:6050` for Talos TCP JSON-lines logs.
+- Keep Talos log labels low-cardinality: `source`, `cluster`, `node`, `stream`, `service`, `level`.
+- Do not add labels for message text, sequence numbers, kernel clock, or raw source address.
+- Debug-level Talos logs are filtered before reaching Loki unless explicitly troubleshooting.
+- The per-node Talos Vector throttle is intentionally conservative at 500 events/sec/node.
+- Logs emitted before host-network `vector-agent` is listening can be dropped; this is accepted.
+- Do not edit `talos/clusterconfig/` directly. Change Talos patches, run `task talos:generate`, then inspect/apply generated node configs.
+
+Useful LogQL:
+
+```logql
+{source="talos", node="k8s-node-1"}
+{source="talos", stream="service", service="kubelet"}
+{source="talos", stream="kernel", level=~"warn|err|error|crit|alert|emerg"}
+sum by (node, stream) (count_over_time({source="talos"}[5m]))
+```

--- a/docs/agent/routing.md
+++ b/docs/agent/routing.md
@@ -1,0 +1,104 @@
+# Routing Conventions
+
+Read this before changing app exposure, HTTPRoutes, Envoy Gateway references, Authelia protection, or Cloudflare Tunnel behavior.
+
+## Gateway API Only
+
+Ingress is handled by Envoy Gateway using Kubernetes Gateway API. Do not add legacy `Ingress` resources.
+
+Two Gateway resources live in the `network` namespace:
+
+- `envoy-internal` (`10.0.88.200`) for local-only apps using `${SECRET_DOMAIN}`.
+- `envoy-external` (`10.0.88.201`) for internet-exposed apps using `${SECRET_PUBLIC_DOMAIN}` via Cloudflare Tunnel.
+
+Both terminate TLS on port 443 with a wildcard certificate and redirect HTTP to HTTPS.
+
+## App-Template Routes
+
+Most apps use the bjw-s app-template `route:` key, which renders HTTPRoute resources.
+
+Internal-only app:
+
+```yaml
+route:
+  app:
+    hostnames:
+      - "app.${SECRET_DOMAIN}"
+    parentRefs:
+      - name: envoy-internal
+        namespace: network
+```
+
+Externally exposed app:
+
+```yaml
+route:
+  app:
+    hostnames:
+      - "app.${SECRET_PUBLIC_DOMAIN}"
+    parentRefs:
+      - name: envoy-external
+        namespace: network
+```
+
+Dual internal and external exposure:
+
+```yaml
+route:
+  internal:
+    hostnames:
+      - "app.${SECRET_DOMAIN}"
+    parentRefs:
+      - name: envoy-internal
+        namespace: network
+  external:
+    hostnames:
+      - "app.${SECRET_PUBLIC_DOMAIN}"
+    parentRefs:
+      - name: envoy-external
+        namespace: network
+```
+
+When default backendRefs are not sufficient, add explicit rules:
+
+```yaml
+route:
+  app:
+    hostnames:
+      - "app.${SECRET_DOMAIN}"
+    parentRefs:
+      - name: envoy-internal
+        namespace: network
+    rules:
+      - backendRefs:
+          - identifier: app
+            port: http
+```
+
+## Authelia Authentication
+
+Apps that need Authelia SSO/ext-auth include the `authelia-proxy` Kustomize component in their app-level `kustomization.yaml`, not in `ks.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+components:
+  - ../../../../components/authelia-proxy
+```
+
+The component creates an Envoy `SecurityPolicy` targeting the app HTTPRoute by name (`${APP}`), forwarding auth checks to `authelia.security.svc.cluster.local`.
+
+A `ReferenceGrant` in the `security` namespace authorises cross-namespace access. If adding Authelia to an app in a new namespace, add that namespace to `kubernetes/apps/security/authelia/app/referencegrant.yaml`.
+
+## Cloudflare Tunnel
+
+External traffic flows:
+
+```text
+Internet → Cloudflare → cloudflared pod → envoy-external Gateway service → app
+```
+
+Cloudflare Tunnel is configured in `kubernetes/apps/network/cloudflared/app/configs/config.yaml` and forwards all `*.${SECRET_PUBLIC_DOMAIN}` traffic to the `envoy-external` service.

--- a/docs/agent/secrets-standards-renovate.md
+++ b/docs/agent/secrets-standards-renovate.md
@@ -1,0 +1,68 @@
+# Secrets, Standards, and Renovate
+
+Read this before touching secrets, encrypted files, schema-backed YAML/JSON, formatting-sensitive files, or Renovate-managed dependencies.
+
+## SOPS and Secret Management
+
+- Encrypted files match `*.sops.yaml`.
+- Encryption uses age keys from `~/.config/sops/age/keys.txt`.
+- Kubernetes secrets encrypt only `data` and `stringData` fields via `encrypted_regex: "^(data|stringData)$"`.
+- Talos secrets encrypt the entire file.
+- Never commit unencrypted secrets or derived secret values.
+- Prefer ExternalSecrets referencing 1Password for application secrets.
+- Cluster-wide variables live in `kubernetes/components/common/vars/cluster-secrets.sops.yaml`.
+- Variables such as `${SECRET_DOMAIN}` are substituted into Flux Kustomizations via `postBuild.substituteFrom`.
+
+## YAML Formatting
+
+- Indent with 2 spaces, never tabs.
+- Use LF line endings and final newlines.
+- Start YAML files with `---`.
+- Include schema comments where applicable:
+
+```yaml
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+```
+
+## Schema Validation
+
+When changing YAML/JSON files that declare a schema, validate the changed file before reporting completion.
+
+Use direct schema checks when no project validator is available:
+
+```bash
+uvx check-jsonschema --schemafile <schema-url> <file>
+```
+
+If validation fails, fix the manifest and re-run validation.
+
+## Shell Scripts
+
+- Use `#!/usr/bin/env bash`.
+- Use `set -Eeuo pipefail`.
+- Indent with 4 spaces.
+
+## Naming Conventions
+
+- App names are lowercase and hyphen-separated, for example `home-assistant`.
+- Kubernetes labels follow `app.kubernetes.io/name: <app-name>`.
+- Flux Kustomization names match app directory names.
+- HelmRelease names match app directory names.
+
+## Renovate
+
+Renovate runs hourly and manages dependency updates.
+
+Key conventions:
+
+- Container images include digest pinning: `tag: v1.0.0@sha256:...`.
+- Talos/Kubernetes versions use annotated comments for Renovate detection:
+
+```yaml
+# renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+TALOS_VERSION: v1.11.3
+```
+
+- CRD URLs in bootstrap scripts use similar annotations.
+- Renovate config lives in `.renovaterc.json5` and `.renovate/`.
+- Semantic commits are enforced, for example `feat(container)!:`, `fix(helm):`, `chore(container):`.


### PR DESCRIPTION
## Summary

- Shrinks always-loaded `AGENTS.md` from a long reference into a high-signal operating contract and read-gate index.
- Moves detailed procedures into focused `docs/agent/` references for application deployments, routing, secrets/standards/Renovate, operations, and platform details.
- Adds an agent docs index explaining why the split exists for Pi's context-loading model.

## Validation

- Reviewed generated diff and file structure.
- Documentation-only change; no Kubernetes manifests changed.
