### PR TITLE
fix: allow users to access babybuddy

### DIFF
--- a/kubernetes/apps/security/authelia/app/config/configuration.yml
+++ b/kubernetes/apps/security/authelia/app/config/configuration.yml
@@ -35,13 +35,14 @@ access_control:
     - domain:
         - "paperless.${SECRET_DOMAIN}"
         - "memos.${SECRET_DOMAIN}"
+        - "baby.${SECRET_PUBLIC_DOMAIN}"
       policy: two_factor
       subject:
         - 'group:users'
     - domain:
         - "grimmory.${SECRET_DOMAIN}"
         - "echo-server.${SECRET_DOMAIN}"
-        - "shelfmark.petrovic.network"
+        - "shelfmark.${SECRET_DOMAIN}"
       policy: one_factor
       subject:
         - 'group:users'


### PR DESCRIPTION
## Summary
- allow `group:users` to access `baby.${SECRET_PUBLIC_DOMAIN}` via Authelia two-factor policy
- replace hard-coded Shelfmark internal hostname with `${SECRET_DOMAIN}` substitution

## Validation
- `kubectl kustomize kubernetes/apps/security/authelia/app`
