### PR TITLE
chore(frigate): mount config from ConfigMap

### DIFF
--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -25,12 +25,6 @@ spec:
       frigate:
         annotations:
           reloader.stakater.com/auto: "true"
-        initContainers:
-          copy-config:
-            image:
-              repository: mirror.gcr.io/library/busybox
-              tag: latest@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
-            command: ["sh", "-c", "cp /config-source/config.yml /config/config.yml"]
         containers:
           app:
             image:
@@ -119,12 +113,10 @@ spec:
       config-file:
         type: configMap
         name: frigate-configmap
-        advancedMounts:
-          frigate:
-            copy-config:
-              - path: /config-source/config.yml
-                subPath: config.yml
-                readOnly: true
+        globalMounts:
+          - path: /config/config.yml
+            subPath: config.yml
+            readOnly: true
       cache:
         enabled: true
         type: emptyDir


### PR DESCRIPTION
## Summary
- remove the BusyBox initContainer that copied Frigate config into the PVC
- mount `frigate-configmap` directly at `/config/config.yml`
- keep `/config` backed by the existing Frigate PVC for runtime state

## Validation
- `uvx check-jsonschema --schemafile https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json kubernetes/apps/automation/frigate/app/helmrelease.yaml`
