### PR TITLE
fix(bootstrap): harden catastrophic rebuild flow

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -3,24 +3,24 @@ SOPS_AGE_KEY_FILE = "/Users/adam/.config/sops/age/keys.txt"
 
 [tools]
 # Kubernetes
-kubectl = "latest"
-helm = "latest"
-helmfile = "latest"
-kustomize = "latest"
-flux2 = "latest"
+kubectl = "1.35.1"
+helm = "4.1.1"
+helmfile = "1.2.3"
+kustomize = "5.8.1"
+flux2 = "2.7.5"
 
 # Talos
-talosctl = "latest"
-talhelper = "latest"
+talosctl = "1.13.0"
+talhelper = "3.1.9"
 
 # Secrets
-sops = "latest"
-age = "latest"
-1password-cli = "latest"
+sops = "3.11.0"
+age = "1.3.1"
+1password-cli = "2.32.1"
 
 # Utilities
-jq = "latest"
-yq = "latest"
-task = "latest"
-fzf = "latest"
-gh = "latest"
+jq = "1.8.1"
+yq = "4.52.2"
+task = "3.48.0"
+fzf = "0.67.0"
+gh = "2.86.0"

--- a/.taskfiles/Bootstrap/Taskfile.yaml
+++ b/.taskfiles/Bootstrap/Taskfile.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+tasks:
+  preflight:
+    desc: Check local tools, credentials, rendering, and Talos node reachability before bootstrap
+    cmd: bash {{.ROOT_DIR}}/scripts/bootstrap-preflight.sh
+
+  verify:
+    desc: Verify the core bootstrap substrate after running scripts/bootstrap-cluster.sh
+    cmd: bash {{.ROOT_DIR}}/scripts/bootstrap-verify.sh --core
+
+  verify-full:
+    desc: Verify full post-bootstrap GitOps convergence, storage, gateways, VolSync, and CNPG
+    cmd: bash {{.ROOT_DIR}}/scripts/bootstrap-verify.sh --full

--- a/README.md
+++ b/README.md
@@ -282,6 +282,11 @@ task talos:upgrade-k8s        # Upgrade Kubernetes version (requires: node=<ip> 
 task talos:reboot-node        # Reboot node (requires: IP=<ip>)
 task talos:nuke               # Reset nodes to maintenance mode (DESTRUCTIVE!)
 
+# Bootstrap / disaster recovery
+task bootstrap:preflight      # Check tools, credentials, rendering, and node reachability
+task bootstrap:verify         # Verify the core bootstrap substrate
+task bootstrap:verify-full    # Verify full GitOps/storage/app convergence
+
 # Volume backup operations
 task volsync:check            # Check volsync repo (requires: app=<name>)
 task volsync:debug            # Debug restic (requires: app=<name>)
@@ -304,11 +309,13 @@ task k8s:delete-failed-pods   # Delete pods with failed status
 
 ### Disaster Recovery
 
-Complete cluster rebuild capability:
-1. **Hardware Reset**: PXE boot into Talos maintenance mode
-2. **Cluster Bootstrap**: Automated via bootstrap scripts
-3. **Backup Restoration**: VolSync automatically restores from Kopia (NFS) or Restic (R2) snapshots
-4. **Full documentation**: See [docs/BOOTSTRAP.md](docs/BOOTSTRAP.md)
+Complete destructive cluster rebuild capability:
+1. **Preflight**: `task bootstrap:preflight` checks tools, credentials, rendering, and Talos node reachability
+2. **Hardware Reset**: PXE boot into Talos maintenance mode or run `task talos:nuke`
+3. **Cluster Bootstrap**: `./scripts/bootstrap-cluster.sh` recreates Talos/Kubernetes and installs Flux
+4. **Backup Restoration**: VolSync automatically restores PVCs from Kopia on NAS/NFS; R2 is the manual fallback copy
+5. **Verification**: `task bootstrap:verify` then `task bootstrap:verify-full`
+6. **Full documentation**: See [docs/BOOTSTRAP.md](docs/BOOTSTRAP.md)
 
 ---
 
@@ -392,18 +399,26 @@ app-name/
 - **Network**: VLAN-capable switch and router/firewall
 - **DNS**: Domain name with Cloudflare DNS management (external), UniFi gateway for internal DNS
 - **Secrets**: 1Password account for secrets management
-- **Tools**: `talosctl`, `kubectl`, `flux`, `task`, `age` (for SOPS)
+- **Tools**: Run `mise install` for the pinned toolchain in `.mise.toml` (`talosctl`, `talhelper`, `kubectl`, `flux`, `helm`, `helmfile`, `sops`, `age`, `op`, `task`, `jq`, `yq`, etc.)
 
 ### Quick Start
 
 1. **Fork this repository** and customize for your environment
 2. **Configure secrets**: Set up SOPS age key and 1Password Connect
-3. **Prepare hardware**: Install Talos Linux on your nodes
-4. **Bootstrap cluster**:
+3. **Prepare hardware**: Boot Talos Linux maintenance mode on your nodes
+4. **Run bootstrap preflight**:
+   ```bash
+   task bootstrap:preflight
+   ```
+5. **Bootstrap cluster**:
    ```bash
    ./scripts/bootstrap-cluster.sh
    ```
-5. **Monitor deployment**: Applications will automatically deploy via GitOps
+6. **Verify convergence**:
+   ```bash
+   task bootstrap:verify
+   task bootstrap:verify-full
+   ```
 
 ### Configuration Areas
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -6,6 +6,7 @@ vars:
   KUBERNETES_DIR: "{{.ROOT_DIR}}/kubernetes"
 
 includes:
+  bootstrap: .taskfiles/Bootstrap/Taskfile.yaml
   github:
     aliases: ["gh"]
     taskfile: .taskfiles/GitHub/Taskfile.yaml

--- a/bootstrap/helmfile.yaml
+++ b/bootstrap/helmfile.yaml
@@ -29,6 +29,7 @@ releases:
 
   - name: cert-manager
     namespace: cert-manager
+    createNamespace: true
     chart: oci://quay.io/jetstack/charts/cert-manager
     version: v1.20.2
     values: ['../kubernetes/apps/cert-manager/cert-manager/app/helm/values.yaml']
@@ -36,6 +37,7 @@ releases:
 
   - name: external-secrets
     namespace: external-secrets
+    createNamespace: true
     chart: oci://ghcr.io/external-secrets/charts/external-secrets
     version: 2.5.0
     values: ['../kubernetes/apps/external-secrets/external-secrets/app/helm/values.yaml']
@@ -49,13 +51,14 @@ releases:
           - --server-side
           - --field-manager=kustomize-controller
           - --filename
-          - ../kubernetes/apps/external-secrets/stores/onepassword/clustersecretstore.yaml
+          - ../kubernetes/apps/external-secrets/external-secrets/stores/onepassword/clustersecretstore.yaml
           - --wait=true
         showlogs: true
     needs: ['cert-manager/cert-manager']
 
   - name: flux-operator
     namespace: flux-system
+    createNamespace: true
     chart: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
     version: 0.50.0
     values: ['../kubernetes/apps/flux-system/flux-operator/app/helm/values.yaml']
@@ -63,6 +66,7 @@ releases:
 
   - name: flux-instance
     namespace: flux-system
+    createNamespace: true
     chart: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
     version: 0.50.0
     values: ['../kubernetes/apps/flux-system/flux-instance/app/helm/values.yaml']

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -1,150 +1,261 @@
+# Catastrophic Bootstrap Runbook
+
+Use this procedure when rebuilding the cluster from scratch after a catastrophic incident. This is the **destructive rebuild** path: nodes are reset to Talos maintenance mode, Kubernetes state is recreated from Git, Ceph OSD disks are allowed to be wiped/recreated, and application PVCs restore primarily from the Kopia repository on the NAS.
+
+Do **not** use this runbook if your goal is to preserve/adopt existing Ceph OSDs. This procedure assumes backups are the source of truth for application data.
+
+## Recovery model
+
+- **Infrastructure source of truth:** this Git repository on `main`.
+- **Secrets source of truth:** 1Password vault `k8s` plus the SOPS age key.
+- **Talos source of truth:** `talos/talconfig.yaml`, `talos/talenv.yaml`, `talos/talsecret.yaml`, and patches under `talos/patches/`.
+- **Primary app PVC restore:** VolSync Kopia restore from the NAS NFS repository at `/volume2/kopia`.
+- **Secondary app backup:** Cloudflare R2 Restic backups. R2 is a fallback/manual restore path, not the default automatic bootstrap restore.
+- **Ceph stance:** always rebuild in this runbook. `wipeDevicesFromOtherClusters: true` is expected for this destructive path.
+
 ## Prerequisites
 
-### Required Tools
+### Workstation tools
 
-The following CLI tools must be installed and accessible in your PATH:
-
-- `helm` - Helm package manager
-- `helmfile` - Helm chart deployment orchestration
-- `jq` - JSON processor
-- `kubectl` - Kubernetes command-line tool
-- `kustomize` - Kubernetes configuration management
-- `op` - 1Password CLI
-- `talosctl` - Talos Linux control tool
-- `yq` - YAML processor
-- `task` - Task runner
-
-### Environment Setup
-
-1. **KUBECONFIG**: Set the `KUBECONFIG` environment variable to specify where the kubeconfig file should be saved:
-   ```bash
-   export KUBECONFIG=~/.kube/config
-   ```
-
-2. **SOPS Age Key**: Ensure the SOPS age key is saved to `~/.config/sops/age/keys.txt`. You can retrieve this from 1Password under the item 'sops-age-key'.
-
-3. **1Password Authentication**: Authenticate with 1Password CLI:
-   ```bash
-   op signin
-   ```
-
-## Resetting Existing Cluster (Optional)
-
-If you have an existing cluster that needs to be reset:
+Install the pinned toolchain from `.mise.toml`:
 
 ```bash
-task talos:nuke
+mise install
+mise trust
 ```
 
-This will reset all nodes back to maintenance mode, wiping state and ephemeral data.
+The bootstrap scripts expect these tools in `PATH`:
 
-Alternatively, you can download `metal-amd64.iso` from the [Talos releases page](https://github.com/siderolabs/talos/releases) matching your current version and manually boot each node into maintenance mode. Nodes should have statically assigned IP addresses from the Unifi DHCP server (`10.0.80.x`).
+- `age`
+- `flux`
+- `helm`
+- `helmfile`
+- `jq`
+- `kubectl`
+- `kustomize`
+- `op`
+- `sops`
+- `talhelper`
+- `talosctl`
+- `task`
+- `yq`
 
-## Bootstrap Process
+### Environment
 
-The bootstrap process can be executed using the automated script:
+```bash
+export KUBECONFIG=~/.kube/config
+```
+
+Authenticate to 1Password:
+
+```bash
+op signin
+op whoami
+```
+
+Ensure the SOPS age key exists locally:
+
+```bash
+test -f ~/.config/sops/age/keys.txt
+```
+
+The bootstrap process also reads Talos secrets and initial Kubernetes secrets from 1Password references in:
+
+- `talos/.env`
+- `bootstrap/resources.yaml.j2`
+
+### Hardware and network
+
+1. Boot each node into Talos maintenance mode, or reset an existing cluster with:
+
+   ```bash
+   task talos:nuke
+   ```
+
+2. Confirm DHCP reservations / static leases are in place for:
+
+   - `k8s-node-1` — `10.0.80.10`
+   - `k8s-node-2` — `10.0.80.11`
+   - `k8s-node-3` — `10.0.80.12`
+   - `k8s-node-4` — `10.0.80.13`
+   - `k8s-node-5` — `10.0.80.14`
+   - Kubernetes API VIP — `10.0.80.99`
+
+3. Confirm the NAS is online and serving NFS for at least:
+
+   - `/volume2/kopia` — primary VolSync restore repository
+   - any app-specific NFS paths used by media/home-automation workloads
+   - `/volume2/garage/*` if Garage object storage is being restored from NAS-backed state
+
+## Preflight
+
+Run preflight before applying Talos configs:
+
+```bash
+task bootstrap:preflight
+```
+
+This checks:
+
+- required CLI tools
+- `KUBECONFIG` parent directory writability
+- required repo files
+- 1Password references used by Talos/bootstrap resources
+- rendering of `bootstrap/helmfile.yaml`, using chart refs from that file
+- rendering of `bootstrap/resources.yaml.j2`
+- rendering of `bootstrap/helmfile.yaml`
+- Talos node reachability in maintenance mode or with generated Talos config
+
+If node reachability must be skipped temporarily:
+
+```bash
+BOOTSTRAP_PREFLIGHT_SKIP_NODES=true task bootstrap:preflight
+```
+
+## Bootstrap
+
+Run the automated bootstrap:
 
 ```bash
 ./scripts/bootstrap-cluster.sh
 ```
 
-This script performs the following steps:
+The script performs these steps:
 
-### 1. Talos Configuration
+1. Generate Talos configuration with `task talos:generate`.
+2. Export and use the generated Talos client config at `talos/clusterconfig/talosconfig`.
+3. Apply Talos machine configs to nodes.
+4. Bootstrap etcd/Kubernetes on a controller node.
+5. Fetch kubeconfig to the exact path in `$KUBECONFIG`.
+6. Wait for all Kubernetes node objects to register.
+7. Apply early CRDs required by Flux-managed resources.
+8. Render and apply bootstrap secrets/namespaces from `bootstrap/resources.yaml.j2`.
+9. Sync bootstrap Helm releases with `bootstrap/helmfile.yaml`:
 
-The script will:
-
-1. **Generate Talos configuration**: Creates node-specific configuration files using `talhelper`:
-   ```bash
-   task talos:generate
-   ```
-   This reads from `talos/talconfig.yaml`, `talos/talenv.yaml`, and `talos/talsecret.yaml` to generate configurations for each node.
-
-2. **Apply configuration to nodes**: Applies the generated configuration to all Talos nodes:
-   ```bash
-   task talos:apply
-   ```
-   Note: If nodes are already configured, the script will skip this step to avoid certificate conflicts.
-
-3. **Bootstrap the cluster**: Initializes the Kubernetes cluster on a controller node:
-   ```bash
-   task talos:bootstrap
-   ```
-   The script will retry this operation until successful, checking for "AlreadyExists" to detect completion.
-
-4. **Fetch kubeconfig**: Downloads the kubeconfig file from a controller node:
-   ```bash
-   talosctl kubeconfig --nodes <controller> --force <kubeconfig-file>
+   ```text
+   Cilium → CoreDNS → Spegel → cert-manager → External Secrets → Flux Operator → Flux Instance
    ```
 
-### 2. Kubernetes Setup
-
-Once Talos is bootstrapped, the script sets up core Kubernetes components:
-
-1. **Wait for nodes**: The script waits for all nodes to be available before proceeding. It uses `talosctl health --server=false` to verify node health.
-
-2. **Apply Custom Resource Definitions (CRDs)**:
-   - External DNS CRDs
-   - Gateway API experimental CRDs
-   - Prometheus Operator CRDs
-   - Network Attachment Definition CRDs (Multus)
-   - Barman Cloud CRDs (CloudNative-PG)
-   - Envoy Gateway CRDs (extracted from Helm chart)
-
-3. **Apply bootstrap resources**: Renders and applies resources from `bootstrap/resources.yaml.j2` using 1Password (`op inject`) to inject secrets. This creates:
-   - `external-secrets`, `flux-system`, and `network` namespaces
-   - 1Password Connect credentials secret
-   - SOPS age key secret for Flux decryption
-   - TLS certificate secret for ingress
-
-4. **Sync Helm releases**: Deploys core infrastructure components using Helmfile in order:
-   ```
-   Cilium → CoreDNS (Helm) → Spegel → cert-manager → External Secrets → Flux Operator → Flux Instance
-   ```
-   ```bash
-   helmfile --file bootstrap/helmfile.yaml sync --hide-notes
-   ```
+Flux then reconciles `kubernetes/flux/cluster/ks.yaml` from `main` and starts applying the full app graph.
 
 ## Verification
 
-After the bootstrap completes, verify the cluster is healthy and starting:
+First verify the core bootstrap substrate:
 
-1. **Check node status**:
-   ```bash
-   kubectl get nodes -o wide
-   ```
-   All nodes should show `Ready` status.
+```bash
+task bootstrap:verify
+```
 
-2. **Verify core resources**:
-   ```bash
-   kubectl get pods -A
-   kubectl get kustomization -A
-   kubectl get helmrelease -A
-   ```
+This checks:
 
-3. **Verify Flux components**:
-   ```bash
-   kubectl -n flux-system get pods -o wide
-   ```
+- Kubernetes API reachability
+- all nodes `Ready=True`
+- Cilium rollout
+- CoreDNS rollout
+- External Secrets pods
+- Flux pods
+- Flux source readiness
 
-## Post-Bootstrap Notes
+After Flux has had time to reconcile the full repository, verify full convergence:
 
-### Storage Considerations
+```bash
+task bootstrap:verify-full
+```
 
-Ensure OSDs are properly configured in `rook-ceph`. With `wipeDevicesFromOtherClusters: true` set, the setup should be seamless. However, avoid installing the Talos system partition on disks designated for Rook-Ceph, as this will cause OSD job failures.
+This additionally checks:
 
-### Certificate Generation
+- `cluster-apps` readiness
+- all Flux Kustomizations and HelmReleases ready
+- `openebs-hostpath`, `ceph-block`, and `csi-ceph-blockpool`
+- Rook Ceph Kustomization readiness
+- VolSync Kustomization readiness
+- Envoy Gateway programming
+- main CNPG `postgres` cluster readiness
+- VolSync ReplicationSource/ReplicationDestination API availability
 
-`cert-manager` may take some time to generate certificates. This is normal - be patient and monitor the certificate resources.
+## Data restoration expectations
 
-### Data Restoration
+### VolSync PVCs
 
-VolSync backups use a dual-storage strategy (Kopia to NFS + Restic to Cloudflare R2). On bootstrap, VolSync will automatically begin restoring volumes from the last available snapshot. Verify that your applications have their data restored after startup.
+Persistent apps using `kubernetes/components/volsync` create PVCs with a `dataSourceRef` to a VolSync `ReplicationDestination`. On a destructive rebuild, those PVCs should restore automatically from the latest Kopia snapshot in the NAS repository.
+
+Important details:
+
+- The default GitOps-created PVC restore uses **Kopia/NFS**. Use the manual R2 procedure if the Kopia repository is unavailable or missing the desired snapshot.
+- The NAS and `/volume2/kopia` must be available before VolSync mover jobs can restore.
+- Cloudflare R2 Restic backups are retained as a secondary disaster copy. Manual R2 restore steps are documented in `kubernetes/components/volsync/README.md`.
+- After bootstrap, inspect VolSync objects and PVCs:
+
+  ```bash
+  kubectl get replicationdestinations,replicationsources -A
+  kubectl get pvc -A
+  ```
+
+### PostgreSQL / CNPG
+
+CNPG clusters use their declarative manifests and backup configuration in Git. During a full rebuild, database readiness can lag behind Flux readiness while operators, object storage, DNS/routing, and backup recovery settle.
+
+Use the full verifier and CNPG checks:
+
+```bash
+task bootstrap:verify-full
+kubectl -n database get cluster postgres
+kubectl -n database describe cluster postgres
+```
+
+### Ceph / Rook
+
+This runbook assumes Ceph is rebuilt, not adopted. Rook is configured with `wipeDevicesFromOtherClusters: true`, so make sure the selected OSD disks in `kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml` are the disks you intend to wipe/reuse.
 
 ## Troubleshooting
 
-- **Bootstrap interruption**: If the bootstrap process is interrupted (e.g., by Ctrl+C), you may need to reset the cluster using `task talos:nuke` before trying again.
-- **Node connectivity**: Ensure all nodes are accessible and have their expected static IP addresses.
-- **1Password authentication**: If you see authentication errors, ensure you're signed into 1Password CLI with `op signin`.
+### Preflight cannot read 1Password refs
 
-The bootstrap process typically takes 10+ minutes. During this time, you may see various error messages like "couldn't get current server API group list" or "error: no matching resources found" - these are normal as services come online.
+Re-authenticate and check vault access:
+
+```bash
+op signin
+op whoami
+op read op://k8s/sops/SOPS_PRIVATE_KEY >/dev/null
+```
+
+### Talos node not reachable
+
+Confirm the node is booted into Talos maintenance mode and has the expected IP:
+
+```bash
+talosctl --nodes 10.0.80.10 version --insecure
+```
+
+If the node was already configured, regenerate Talos config and try authenticated access:
+
+```bash
+task talos:generate
+TALOSCONFIG=talos/clusterconfig/talosconfig talosctl --nodes 10.0.80.10 version
+```
+
+### Bootstrap interrupted
+
+If interruption happened before Kubernetes was healthy, reset back to maintenance mode and rerun:
+
+```bash
+task talos:nuke
+./scripts/bootstrap-cluster.sh
+```
+
+### Flux is installed but apps are still reconciling
+
+Check Flux state:
+
+```bash
+kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A
+kubectl get helmreleases.helm.toolkit.fluxcd.io -A
+flux get kustomizations -A
+flux get helmreleases -A
+```
+
+Then rerun:
+
+```bash
+task bootstrap:verify-full
+```

--- a/kubernetes/components/volsync/README.md
+++ b/kubernetes/components/volsync/README.md
@@ -123,9 +123,196 @@ kubectl get kopiamaintenance -A
 
 The Kopia server provides a web interface for browsing and managing backups. It connects to the same NFS-backed repository that the VolSync movers use.
 
+## Manual R2 Restore
+
+The component creates two independent backup paths:
+
+- `${APP}-volsync-secret` + `${APP}-dst` use Kopia on the NAS and drive the automatic PVC restore path in `claim.yaml`.
+- `${APP}-volsync-r2-secret` + `${APP}-r2` use Restic on Cloudflare R2 and create secondary backups only.
+
+VolSync does **not** automatically fall back from Kopia/NFS to R2. If the NAS Kopia repository is unavailable or missing the desired snapshot, restore from R2 by creating a temporary Restic `ReplicationDestination` that references `${APP}-volsync-r2-secret`.
+
+### Prerequisites
+
+Set the app, namespace, capacity, and restore identity. Most apps use UID/GID `568`; check the app's `ReplicationSource` if unsure.
+
+```bash
+export app=actual-budget
+export ns=default
+export capacity=2Gi
+export storageClass=ceph-block
+export snapshotClass=csi-ceph-blockpool
+export puid=568
+export pgid=568
+```
+
+Confirm the R2 repository secret exists:
+
+```bash
+kubectl -n "${ns}" get secret "${app}-volsync-r2-secret"
+```
+
+Optionally inspect R2 snapshots directly with Restic:
+
+```bash
+kubectl -n "${ns}" run "restic-list-${app}" \
+  --rm -it --restart=Never \
+  --image=docker.io/restic/restic:0.16.4 \
+  --env-from="secretRef/name=${app}-volsync-r2-secret" \
+  -- snapshots
+```
+
+### Fresh rebuild fallback before the PVC is populated
+
+Use this when the GitOps-created PVC is still pending because the default Kopia/NFS `ReplicationDestination` cannot produce a snapshot.
+
+#### 1. Suspend the app Kustomization
+
+Suspend the app Kustomization so Flux does not replace the temporary R2 restore object while it is running:
+
+```bash
+flux -n flux-system suspend kustomization "${app}"
+```
+
+#### 2. Replace the Kopia destination with a Restic/R2 destination
+
+The PVC already points its `dataSourceRef` at `${app}-dst`, so use the same `ReplicationDestination` name and switch the mover to Restic. Volume-populator restores require `copyMethod: Snapshot`.
+
+```bash
+kubectl -n "${ns}" delete replicationdestination "${app}-dst" --ignore-not-found
+
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: ${app}-dst
+  namespace: ${ns}
+  labels:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+spec:
+  trigger:
+    manual: restore-once
+  restic:
+    repository: ${app}-volsync-r2-secret
+    copyMethod: Snapshot
+    accessModes: [ReadWriteOnce]
+    capacity: ${capacity}
+    storageClassName: ${storageClass}
+    volumeSnapshotClassName: ${snapshotClass}
+    cacheCapacity: 4Gi
+    cacheStorageClassName: openebs-hostpath
+    cacheAccessModes: [ReadWriteOnce]
+    enableFileDeletion: true
+    moverSecurityContext:
+      runAsUser: ${puid}
+      runAsGroup: ${pgid}
+      fsGroup: ${pgid}
+      fsGroupChangePolicy: OnRootMismatch
+EOF
+```
+
+#### 3. Recreate the PVC if needed
+
+If the PVC was deleted or never created, recreate it with the same `dataSourceRef` used by the component:
+
+```bash
+kubectl -n "${ns}" get pvc "${app}" >/dev/null 2>&1 || cat <<EOF | kubectl apply -f -
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${app}
+  namespace: ${ns}
+spec:
+  accessModes: [ReadWriteOnce]
+  dataSourceRef:
+    kind: ReplicationDestination
+    apiGroup: volsync.backube
+    name: ${app}-dst
+  resources:
+    requests:
+      storage: ${capacity}
+  storageClassName: ${storageClass}
+EOF
+```
+
+#### 4. Wait for restore and PVC binding
+
+```bash
+bash .taskfiles/VolSync/scripts/wait-for-replicationdestination.sh "${app}-dst" "${ns}" 7200
+kubectl -n "${ns}" wait pvc/"${app}" --for=jsonpath='{.status.phase}'=Bound --timeout=10m
+```
+
+#### 5. Clean up and resume Flux
+
+Delete the temporary R2 destination and resume Flux. Flux will recreate the normal Kopia destination for future restores/backups.
+
+```bash
+kubectl -n "${ns}" delete replicationdestination "${app}-dst"
+flux -n flux-system resume kustomization "${app}"
+```
+
+### Restore R2 into an existing bound PVC
+
+Use this when the PVC already exists and you want to overwrite its contents from R2.
+
+#### 1. Suspend Flux and stop the workload
+
+No process should write to the PVC during restore:
+
+```bash
+flux -n flux-system suspend kustomization "${app}"
+flux -n "${ns}" suspend helmrelease "${app}" || true
+kubectl -n "${ns}" scale deploy,statefulset -l "app.kubernetes.io/name=${app}" --replicas=0
+```
+
+#### 2. Restore directly into the existing PVC
+
+Apply a temporary Restic `ReplicationDestination` that writes directly into the existing PVC:
+
+```bash
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: ${app}-r2-restore
+  namespace: ${ns}
+spec:
+  trigger:
+    manual: restore-once
+  restic:
+    repository: ${app}-volsync-r2-secret
+    destinationPVC: ${app}
+    copyMethod: Direct
+    cacheCapacity: 4Gi
+    cacheStorageClassName: openebs-hostpath
+    cacheAccessModes: [ReadWriteOnce]
+    enableFileDeletion: true
+    moverSecurityContext:
+      runAsUser: ${puid}
+      runAsGroup: ${pgid}
+      fsGroup: ${pgid}
+      fsGroupChangePolicy: OnRootMismatch
+EOF
+```
+
+To restore an older snapshot, add either `previous: <n>` or `restoreAsOf: "<RFC3339 timestamp>"` under `spec.restic` before applying.
+
+#### 3. Wait, clean up, and resume the app
+
+```bash
+bash .taskfiles/VolSync/scripts/wait-for-replicationdestination.sh "${app}-r2-restore" "${ns}" 7200
+kubectl -n "${ns}" delete replicationdestination "${app}-r2-restore"
+flux -n "${ns}" resume helmrelease "${app}" || true
+flux -n flux-system resume kustomization "${app}"
+```
+
 ### Common Issues
 
 1. **Backup Pod Fails**: Check storage class availability and CSI snapshot support
 2. **NFS Mount Issues**: Verify the NFS admission policy is working (`kubectl get mutatingadmissionpolicybinding`)
 3. **Restore Hangs**: Verify repository credentials and NFS connectivity
 4. **PVC Not Created**: Ensure ReplicationDestination is in Ready state before PVC creation
+5. **R2 Restore Fails**: Verify `${APP}-volsync-r2-secret`, R2 credentials, cache PVC capacity, and the Restic snapshot selection (`previous` / `restoreAsOf`)

--- a/scripts/bootstrap-cluster.sh
+++ b/scripts/bootstrap-cluster.sh
@@ -1,88 +1,141 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-source "$(dirname "${0}")/lib/common.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/common.sh"
 
-export LOG_LEVEL="debug"
-export ROOT_DIR="$(git rev-parse --show-toplevel)"
+export LOG_LEVEL="${LOG_LEVEL:-debug}"
+export ROOT_DIR="${ROOT_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+export TALOSCONFIG="${TALOSCONFIG:-${ROOT_DIR}/talos/clusterconfig/talosconfig}"
 
-# Apply the Talos configuration to all the nodes
+# Generate the Talos configuration before reading talosctl config state. This makes
+# the bootstrap path work from a clean workstation that has no ~/.talos/config yet.
+function generate_talos_config() {
+    log debug "Generating Talos node configuration"
+
+    task --dir "${ROOT_DIR}" talos:generate
+
+    if [[ ! -f "${TALOSCONFIG}" ]]; then
+        log error "Generated Talos config does not exist" "file=${TALOSCONFIG}"
+    fi
+
+    log info "Talos client configuration is available" "file=${TALOSCONFIG}"
+}
+
+function talos_controller() {
+    local controller
+
+    if ! controller=$(talosctl --talosconfig "${TALOSCONFIG}" config info --output json | jq --exit-status --raw-output '.endpoints[0] // empty') || [[ -z "${controller}" ]]; then
+        log error "No Talos controller endpoint found" "talosconfig=${TALOSCONFIG}"
+    fi
+
+    echo "${controller}"
+}
+
+function expected_node_count() {
+    yq '.nodes | length' "${ROOT_DIR}/talos/talconfig.yaml"
+}
+
+# Apply the Talos configuration to all the nodes.
 function apply_talos_config() {
     log debug "Applying Talos configuration"
 
-    if ! nodes=$(talosctl config info --output json 2>/dev/null | jq --exit-status --raw-output '.nodes | join(" ")') || [[ -z "${nodes}" ]]; then
-        log error "No Talos nodes found"
-    fi
-
-    # generate and apply the configuration
-    log debug "Generating talos node configuration"
-    task talos:generate
-
-    log debug "Applying talos node configuration"
-    if ! output=$(task talos:apply 2>&1); then
+    log debug "Applying Talos node configuration"
+    if ! output=$(task --dir "${ROOT_DIR}" talos:apply 2>&1); then
         if [[ "${output}" == *"certificate required"* ]]; then
-            log warn "Talos node is already configured, skipping apply of config"
+            log warn "At least one Talos node is already configured; skipping insecure apply for configured nodes"
             return
         fi
-        log error "Failed to apply Talos node configuration"
+        log error "Failed to apply Talos node configuration" "output=${output}"
     fi
 
     log info "Talos node configuration applied successfully"
 }
 
-# Bootstrap Talos on a controller node
+# Bootstrap Talos on a controller node.
 function bootstrap_talos() {
+    local controller output start now timeout
+
     log debug "Bootstrapping Talos"
 
-    if ! controller=$(talosctl config info --output json | jq --exit-status --raw-output '.endpoints[]' | shuf -n 1) || [[ -z "${controller}" ]]; then
-        log error "No Talos controller found"
-    fi
+    controller="$(talos_controller)"
+    timeout="${TALOS_BOOTSTRAP_TIMEOUT_SECONDS:-900}"
+    start="$(date +%s)"
 
     log debug "Talos controller discovered" "controller=${controller}"
 
-    until output=$(task talos:bootstrap) && [[ "${output}" == *"AlreadyExists"* ]]; do
+    while true; do
+        if output=$(task --dir "${ROOT_DIR}" talos:bootstrap 2>&1); then
+            log info "Talos bootstrap command completed" "controller=${controller}"
+            return
+        fi
+
+        if [[ "${output}" == *"AlreadyExists"* || "${output}" == *"already bootstrapped"* ]]; then
+            log info "Talos is already bootstrapped" "controller=${controller}"
+            return
+        fi
+
+        now="$(date +%s)"
+        if ((now - start >= timeout)); then
+            log error "Timed out waiting for Talos bootstrap" "controller=${controller}" "timeout=${timeout}s" "output=${output}"
+        fi
+
         log info "Talos bootstrap in progress, waiting 10 seconds..." "controller=${controller}"
         sleep 10
     done
-
-    log info "Talos is bootstrapped" "controller=${controller}"
 }
 
-# Fetch the kubeconfig from a controller node
+# Fetch the kubeconfig from a controller node.
 function fetch_kubeconfig() {
+    local controller kubeconfig_dir
+
     log debug "Fetching kubeconfig"
 
-    if ! controller=$(talosctl config info --output json | jq --exit-status --raw-output '.endpoints[]' | shuf -n 1) || [[ -z "${controller}" ]]; then
-        log error "No Talos controller found"
+    controller="$(talos_controller)"
+    kubeconfig_dir="$(dirname "${KUBECONFIG}")"
+    mkdir -p "${kubeconfig_dir}"
+
+    if ! talosctl --talosconfig "${TALOSCONFIG}" kubeconfig --nodes "${controller}" --force "${KUBECONFIG}" &>/dev/null; then
+        log error "Failed to fetch kubeconfig" "controller=${controller}" "kubeconfig=${KUBECONFIG}"
     fi
 
-    if ! talosctl kubeconfig --nodes "${controller}" --force "$(basename "${KUBECONFIG}")" &>/dev/null; then
-        log error "Failed to fetch kubeconfig"
-    fi
-
-    log info "Kubeconfig fetched successfully"
+    log info "Kubeconfig fetched successfully" "file=${KUBECONFIG}"
 }
 
-# Talos requires the nodes to be 'Ready=False' before applying resources
+# Wait for Kubernetes node objects to exist before applying API resources. On a
+# fresh cluster with no CNI yet, nodes are expected to appear as Ready=False.
 function wait_for_nodes() {
-    log debug "Waiting for nodes to be available"
+    local expected count start now timeout
 
-    # Skip waiting if all nodes are 'Ready=True'
-    if kubectl wait nodes --for=condition=Ready=True --all --timeout=10s &>/dev/null; then
-        log info "Nodes are available and ready, skipping wait for nodes"
-        return
-    fi
+    log debug "Waiting for Kubernetes node objects"
 
-    # Wait for all nodes to be 'Ready=False'
-    until kubectl wait nodes --for=condition=Ready=False --all --timeout=10s &>/dev/null; do
-        log info "Nodes are not available, waiting for nodes to be available. Retrying in 10 seconds..."
+    expected="$(expected_node_count)"
+    timeout="${NODE_DISCOVERY_TIMEOUT_SECONDS:-600}"
+    start="$(date +%s)"
+
+    until count=$(kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ') && [[ "${count}" =~ ^[0-9]+$ ]] && ((count >= expected)); do
+        now="$(date +%s)"
+        if ((now - start >= timeout)); then
+            log error "Timed out waiting for Kubernetes nodes to register" "expected=${expected}" "seen=${count:-0}" "timeout=${timeout}s"
+        fi
+        log info "Waiting for Kubernetes nodes to register" "expected=${expected}" "seen=${count:-0}"
         sleep 10
     done
 
-    talosctl health --server=false
+    if kubectl wait nodes --for=condition=Ready=True --all --timeout=10s &>/dev/null; then
+        log info "Nodes are already Ready; continuing"
+        return
+    fi
+
+    until kubectl wait nodes --for=condition=Ready=False --all --timeout=10s &>/dev/null; do
+        log info "Nodes are registered but not all have Ready=False yet; retrying in 10 seconds..."
+        sleep 10
+    done
+
+    talosctl --talosconfig "${TALOSCONFIG}" health --server=false --wait-timeout=20m
 }
 
-# CRDs to be applied before the helmfile charts are installed
+# CRDs to be applied before the helmfile charts are installed.
 function apply_crds() {
     log debug "Applying CRDs"
 
@@ -111,20 +164,20 @@ function apply_crds() {
         fi
     done
 
-    # Extract and apply CRDs from Helm charts (matching onedr0p/home-ops pattern)
+    # Extract and apply CRDs from Helm charts (matching onedr0p/home-ops pattern).
     local -r helm_crds=(
         # renovate: datasource=docker depName=docker.io/envoyproxy/gateway-helm
-        "oci://docker.io/envoyproxy/gateway-helm 1.7.0"
+        "oci://docker.io/envoyproxy/gateway-helm 1.8.0"
     )
 
     for entry in "${helm_crds[@]}"; do
         local chart="${entry% *}"
         local version="${entry#* }"
-        local tmpdir
-        tmpdir=$(mktemp -d)
+        local tmpdir crds_dir
+
+        tmpdir="$(mktemp -d)"
         if helm pull "${chart}" --version "${version}" --untar --untardir "${tmpdir}" &>/dev/null; then
-            local crds_dir
-            crds_dir=$(find "${tmpdir}" -type d -name crds | head -1)
+            crds_dir="$(find "${tmpdir}" -type d -name crds | head -1)"
             if [[ -n "${crds_dir}" ]]; then
                 if kubectl apply --server-side --force-conflicts -f "${crds_dir}" --recursive &>/dev/null; then
                     log info "Helm chart CRDs applied" "chart=${chart}" "version=${version}"
@@ -139,7 +192,7 @@ function apply_crds() {
     done
 }
 
-# Resources to be applied before the helmfile charts are installed
+# Resources to be applied before the helmfile charts are installed.
 function apply_resources() {
     log debug "Applying resources"
 
@@ -161,7 +214,7 @@ function apply_resources() {
     fi
 }
 
-# Sync Helm releases
+# Sync Helm releases.
 function sync_helm_releases() {
     log debug "Syncing Helm releases"
 
@@ -180,24 +233,26 @@ function sync_helm_releases() {
 
 function main() {
     check_env KUBECONFIG
-    check_cli helm helmfile jq kubectl kustomize op talosctl yq task
+    check_cli helm helmfile jq kubectl kustomize op sops talhelper talosctl task yq
 
     if ! op whoami --format=json &>/dev/null; then
         log error "Failed to authenticate with 1Password CLI"
     fi
 
-    # Bootstrap the Talos node configuration
+    # Bootstrap the Talos node configuration.
+    generate_talos_config
     apply_talos_config
     bootstrap_talos
     fetch_kubeconfig
 
-    # Apply resources and Helm releases
+    # Apply resources and Helm releases.
     wait_for_nodes
     apply_crds
     apply_resources
     sync_helm_releases
 
     log info "Congrats! The cluster is bootstrapped and Flux is syncing the Git repository"
+    log info "Run post-bootstrap verification with: task bootstrap:verify"
 }
 
 main "$@"

--- a/scripts/bootstrap-preflight.sh
+++ b/scripts/bootstrap-preflight.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/common.sh"
+
+export LOG_LEVEL="${LOG_LEVEL:-info}"
+export ROOT_DIR="${ROOT_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+export TALOSCONFIG="${TALOSCONFIG:-${ROOT_DIR}/talos/clusterconfig/talosconfig}"
+
+failures=0
+
+function fail_check() {
+    log warn "$@"
+    failures=$((failures + 1))
+}
+
+function check_file() {
+    local file="${1}"
+
+    if [[ -f "${file}" ]]; then
+        log info "Required file exists" "file=${file}"
+    else
+        fail_check "Required file is missing" "file=${file}"
+    fi
+}
+
+function check_op_refs() {
+    local refs_file ref
+
+    refs_file="$(mktemp)"
+    grep -RhoE 'op://[^[:space:]}",]+' \
+        "${ROOT_DIR}/talos/.env" \
+        "${ROOT_DIR}/bootstrap/resources.yaml.j2" \
+        | sort -u >"${refs_file}"
+
+    while IFS= read -r ref; do
+        [[ -z "${ref}" ]] && continue
+        if op read "${ref}" >/dev/null 2>&1; then
+            log info "1Password reference is readable" "ref=${ref}"
+        else
+            fail_check "1Password reference is not readable" "ref=${ref}"
+        fi
+    done <"${refs_file}"
+
+    rm -f "${refs_file}"
+}
+
+function check_talos_nodes() {
+    local ip
+
+    if [[ "${BOOTSTRAP_PREFLIGHT_SKIP_NODES:-false}" == "true" ]]; then
+        log warn "Skipping Talos node reachability checks" "BOOTSTRAP_PREFLIGHT_SKIP_NODES=true"
+        return
+    fi
+
+    if [[ ! -f "${TALOSCONFIG}" ]]; then
+        log info "Generating Talos config for node reachability checks" "file=${TALOSCONFIG}"
+        if ! task --dir "${ROOT_DIR}" talos:generate; then
+            fail_check "Failed to generate Talos config for node checks" "file=${TALOSCONFIG}"
+            return
+        fi
+    fi
+
+    while IFS= read -r ip; do
+        [[ -z "${ip}" ]] && continue
+        if talosctl --nodes "${ip}" version --insecure >/dev/null 2>&1; then
+            log info "Talos node is reachable in maintenance mode" "node=${ip}"
+        elif talosctl --talosconfig "${TALOSCONFIG}" --nodes "${ip}" version >/dev/null 2>&1; then
+            log info "Talos node is reachable with generated config" "node=${ip}"
+        else
+            fail_check "Talos node is not reachable" "node=${ip}"
+        fi
+    done < <(yq '.nodes[].ipAddress' "${ROOT_DIR}/talos/talconfig.yaml")
+}
+
+function check_rendering() {
+    if render_template "${ROOT_DIR}/bootstrap/resources.yaml.j2" >/dev/null; then
+        log info "Bootstrap resources render with 1Password injection"
+    else
+        fail_check "Bootstrap resources failed to render"
+    fi
+
+    if helmfile --file "${ROOT_DIR}/bootstrap/helmfile.yaml" build >/dev/null; then
+        log info "Bootstrap Helmfile renders with chart refs from bootstrap/helmfile.yaml"
+    else
+        fail_check "Bootstrap Helmfile failed to render"
+    fi
+}
+
+function main() {
+    check_env KUBECONFIG
+    check_cli flux helm helmfile jq kubectl kustomize op sops talhelper talosctl task yq
+
+    if ! op whoami --format=json >/dev/null 2>&1; then
+        log error "Failed to authenticate with 1Password CLI"
+    fi
+
+    mkdir -p "$(dirname "${KUBECONFIG}")"
+    if [[ ! -w "$(dirname "${KUBECONFIG}")" ]]; then
+        fail_check "KUBECONFIG directory is not writable" "directory=$(dirname "${KUBECONFIG}")"
+    fi
+
+    check_file "${ROOT_DIR}/talos/.env"
+    check_file "${ROOT_DIR}/talos/talconfig.yaml"
+    check_file "${ROOT_DIR}/talos/talenv.yaml"
+    check_file "${ROOT_DIR}/talos/talsecret.yaml"
+    check_file "${ROOT_DIR}/bootstrap/helmfile.yaml"
+    check_file "${ROOT_DIR}/bootstrap/resources.yaml.j2"
+    check_file "${ROOT_DIR}/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/clustersecretstore.yaml"
+
+    check_op_refs
+    check_rendering
+    check_talos_nodes
+
+    if ((failures > 0)); then
+        log error "Bootstrap preflight failed" "failures=${failures}"
+    fi
+
+    log info "Bootstrap preflight passed"
+}
+
+main "$@"

--- a/scripts/bootstrap-verify.sh
+++ b/scripts/bootstrap-verify.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/common.sh"
+
+export LOG_LEVEL="${LOG_LEVEL:-info}"
+export ROOT_DIR="${ROOT_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+
+failures=0
+mode="core"
+
+function usage() {
+    cat <<'EOF'
+Usage: scripts/bootstrap-verify.sh [--core|--full]
+
+  --core  Verify the bootstrap substrate: nodes, CNI, DNS, External Secrets, and Flux.
+  --full  Also verify Flux convergence, storage, gateways, VolSync objects, and CNPG.
+EOF
+}
+
+function fail_check() {
+    log warn "$@"
+    failures=$((failures + 1))
+}
+
+function run_check() {
+    local description="${1}"
+    shift
+
+    if "$@"; then
+        log info "Check passed" "check=${description}"
+    else
+        fail_check "Check failed" "check=${description}"
+    fi
+}
+
+function wait_for_nodes() {
+    kubectl wait nodes --for=condition=Ready=True --all --timeout="${NODE_READY_TIMEOUT:-15m}" >/dev/null
+}
+
+function wait_for_namespace_pods() {
+    local namespace="${1}"
+    local timeout="${2:-10m}"
+
+    kubectl -n "${namespace}" wait pods --all --for=condition=Ready --timeout="${timeout}" >/dev/null
+}
+
+function wait_for_flux_object() {
+    local namespace="${1}"
+    local kind="${2}"
+    local name="${3}"
+    local timeout="${4:-10m}"
+
+    kubectl -n "${namespace}" wait "${kind}/${name}" --for=condition=Ready --timeout="${timeout}" >/dev/null
+}
+
+function count_not_ready() {
+    local resource="${1}"
+
+    kubectl get "${resource}" --all-namespaces -o json \
+        | jq '[.items[] | select(((.status.conditions // []) | map(select(.type == "Ready")) | .[0].status // "False") != "True")] | length'
+}
+
+function check_flux_convergence() {
+    local ks_not_ready hr_not_ready
+
+    ks_not_ready="$(count_not_ready kustomizations.kustomize.toolkit.fluxcd.io)"
+    hr_not_ready="$(count_not_ready helmreleases.helm.toolkit.fluxcd.io)"
+
+    if [[ "${ks_not_ready}" == "0" && "${hr_not_ready}" == "0" ]]; then
+        return 0
+    fi
+
+    log warn "Flux objects are not fully ready" "kustomizations=${ks_not_ready}" "helmreleases=${hr_not_ready}"
+    kubectl get kustomizations.kustomize.toolkit.fluxcd.io --all-namespaces || true
+    kubectl get helmreleases.helm.toolkit.fluxcd.io --all-namespaces || true
+    return 1
+}
+
+function check_full_convergence() {
+    run_check "cluster-apps Kustomization ready" wait_for_flux_object flux-system kustomization cluster-apps "${CLUSTER_APPS_TIMEOUT:-30m}"
+    run_check "Flux Kustomizations and HelmReleases ready" check_flux_convergence
+
+    run_check "openebs-hostpath StorageClass exists" kubectl get storageclass openebs-hostpath
+    run_check "ceph-block StorageClass exists" kubectl get storageclass ceph-block
+    run_check "csi-ceph-blockpool VolumeSnapshotClass exists" kubectl get volumesnapshotclass csi-ceph-blockpool
+
+    run_check "Rook Ceph cluster Kustomization ready" wait_for_flux_object rook-ceph kustomization rook-ceph-cluster "${ROOK_TIMEOUT:-30m}"
+    run_check "VolSync Kustomization ready" wait_for_flux_object volsync-system kustomization volsync "${VOLSYNC_TIMEOUT:-15m}"
+    run_check "Envoy internal Gateway programmed" kubectl -n network wait gateway/envoy-internal --for=condition=Programmed=True --timeout="${GATEWAY_TIMEOUT:-10m}"
+    run_check "Envoy external Gateway programmed" kubectl -n network wait gateway/envoy-external --for=condition=Programmed=True --timeout="${GATEWAY_TIMEOUT:-10m}"
+
+    if kubectl -n database get clusters.postgresql.cnpg.io postgres >/dev/null 2>&1; then
+        run_check "CNPG postgres cluster ready" kubectl -n database wait clusters.postgresql.cnpg.io/postgres --for=condition=Ready --timeout="${CNPG_TIMEOUT:-30m}"
+    else
+        fail_check "CNPG postgres cluster is missing" "namespace=database" "name=postgres"
+    fi
+
+    run_check "VolSync ReplicationDestinations listable" kubectl get replicationdestinations.volsync.backube --all-namespaces
+    run_check "VolSync ReplicationSources listable" kubectl get replicationsources.volsync.backube --all-namespaces
+}
+
+function main() {
+    while [[ $# -gt 0 ]]; do
+        case "${1}" in
+            --core)
+                mode="core"
+                ;;
+            --full)
+                mode="full"
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                usage >&2
+                exit 2
+                ;;
+        esac
+        shift
+    done
+
+    check_env KUBECONFIG
+    check_cli flux jq kubectl
+
+    run_check "Kubernetes API reachable" kubectl version --request-timeout=10s
+    run_check "all Kubernetes nodes Ready" wait_for_nodes
+    run_check "Cilium DaemonSet rolled out" kubectl -n kube-system rollout status daemonset/cilium --timeout="${CILIUM_TIMEOUT:-10m}"
+    run_check "CoreDNS Deployment rolled out" kubectl -n kube-system rollout status deployment/coredns --timeout="${COREDNS_TIMEOUT:-5m}"
+    run_check "External Secrets pods Ready" wait_for_namespace_pods external-secrets "${EXTERNAL_SECRETS_TIMEOUT:-10m}"
+    run_check "Flux pods Ready" wait_for_namespace_pods flux-system "${FLUX_TIMEOUT:-10m}"
+    run_check "Flux source ready" wait_for_flux_object flux-system gitrepository flux-system "${FLUX_TIMEOUT:-10m}"
+
+    if [[ "${mode}" == "full" ]]; then
+        check_full_convergence
+    else
+        log info "Core bootstrap verification complete; run 'task bootstrap:verify-full' for full GitOps convergence"
+    fi
+
+    if ((failures > 0)); then
+        log error "Bootstrap verification failed" "failures=${failures}" "mode=${mode}"
+    fi
+
+    log info "Bootstrap verification passed" "mode=${mode}"
+}
+
+main "$@"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,43 +1,47 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# Log messages with different levels
+function log_level_priority() {
+    case "${1:-info}" in
+        debug) echo 1 ;;
+        info) echo 2 ;;
+        warn) echo 3 ;;
+        error) echo 4 ;;
+        *) echo 2 ;;
+    esac
+}
+
+function log_level_color() {
+    case "${1:-info}" in
+        debug) printf "\\033[1m\\033[38;5;63m" ;;  # Blue
+        warn) printf "\\033[1m\\033[38;5;192m" ;;  # Yellow
+        error) printf "\\033[1m\\033[38;5;198m" ;; # Red
+        info|*) printf "\\033[1m\\033[38;5;87m" ;; # Cyan
+    esac
+}
+
+# Log messages with different levels. Keep this Bash 3 compatible for macOS
+# recovery workstations, so avoid associative arrays.
 function log() {
     local level="${1:-info}"
-    shift
+    shift || true
 
-    # Define log levels with their priorities
-    local -A level_priority=(
-        [debug]=1
-        [info]=2
-        [warn]=3
-        [error]=4
-    )
+    local current_priority
+    current_priority="$(log_level_priority "${level}")"
 
-    # Get the current log level's priority
-    local current_priority=${level_priority[$level]:-2} # Default to "info" priority
-
-    # Get the configured log level from the environment, default to "info"
-    local configured_level=${LOG_LEVEL:-info}
-    local configured_priority=${level_priority[$configured_level]:-2}
+    local configured_level="${LOG_LEVEL:-info}"
+    local configured_priority
+    configured_priority="$(log_level_priority "${configured_level}")"
 
     # Skip log messages below the configured log level
     if ((current_priority < configured_priority)); then
         return
     fi
 
-    # Define log colors
-    local -A colors=(
-        [debug]="\033[1m\033[38;5;63m"  # Blue
-        [info]="\033[1m\033[38;5;87m"   # Cyan
-        [warn]="\033[1m\033[38;5;192m"  # Yellow
-        [error]="\033[1m\033[38;5;198m" # Red
-    )
-
-    # Fallback to "info" if the color for the given level is not defined
-    local color="${colors[$level]:-${colors[info]}}"
-    local msg="$1"
-    shift
+    local color
+    color="$(log_level_color "${level}")"
+    local msg="${1:-}"
+    shift || true
 
     # Prepare additional data
     local data=
@@ -57,9 +61,12 @@ function log() {
         output_stream="/dev/stderr"
     fi
 
+    local upper_level
+    upper_level="$(printf "%s" "${level}" | tr "[:lower:]" "[:upper:]")"
+
     # Print the log message
     printf "%s %b%s%b %s %b\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-        "${color}" "${level^^}" "\033[0m" "${msg}" "${data}" >"${output_stream}"
+        "${color}" "${upper_level}" "\033[0m" "${msg}" "${data}" >"${output_stream}"
 
     # Exit if the log level is error
     if [[ "$level" == "error" ]]; then


### PR DESCRIPTION
## Summary
- harden `scripts/bootstrap-cluster.sh` for clean-workstation catastrophic rebuilds
- add `task bootstrap:preflight`, `task bootstrap:verify`, and `task bootstrap:verify-full`
- fix bootstrap Helmfile namespace creation and External Secrets hook path
- document destructive rebuild expectations, Kopia/NFS default automatic restore, and R2 manual fallback
- add VolSync component documentation for manual Cloudflare R2 Restic restores
- pin bootstrap tool versions in `.mise.toml`
- make shared bootstrap logging Bash 3 compatible for macOS recovery workstations

## Preflight scope
- validates local tools, required files, 1Password refs, bootstrap resource rendering, Helmfile rendering, and Talos node reachability
- chart references are read from `bootstrap/helmfile.yaml` via `helmfile build`; the preflight script does not duplicate hardcoded chart versions
- CRD URL reachability checks were intentionally left out to avoid duplicating the annotated CRD URLs in `scripts/bootstrap-cluster.sh`

## Validation
- `bash -n scripts/bootstrap-cluster.sh scripts/bootstrap-preflight.sh scripts/bootstrap-verify.sh scripts/lib/common.sh`
- `task --list | rg 'bootstrap:'`
- `helmfile --file bootstrap/helmfile.yaml build`
- `helmfile --file bootstrap/helmfile.yaml template --include-crds`
- `flux build kustomization cluster-apps --path ./kubernetes/apps --kustomization-file ./kubernetes/flux/cluster/ks.yaml --dry-run --recursive --local-sources GitRepository/flux-system/flux-system=.`
- `uvx check-jsonschema --schemafile https://json.schemastore.org/helmfile bootstrap/helmfile.yaml`
- `uvx check-jsonschema --schemafile https://taskfile.dev/schema.json Taskfile.yaml .taskfiles/Bootstrap/Taskfile.yaml`
- embedded YAML examples in `kubernetes/components/volsync/README.md` parse successfully

## Live test run
- `KUBECONFIG=$HOME/.kube/config task bootstrap:verify` passed against the current cluster
- `KUBECONFIG=$HOME/.kube/config task bootstrap:verify-full` passed against the current cluster
- `KUBECONFIG=$HOME/.kube/config task bootstrap:preflight` executed far enough to validate script startup/logging but stopped at 1Password authentication because this shell session is not signed in to `op`

## Notes
- I did not run `scripts/bootstrap-cluster.sh` against the live cluster because it mutates Talos/Kubernetes and is intended for fresh/reset nodes.
- This intentionally keeps the first pass scoped to bootstrap automation/docs, not CNPG/Rook behaviour changes beyond documenting the destructive rebuild stance.
