### PR TITLE
chore(renovate): group mise tool updates

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -14,6 +14,15 @@
       versioning: "loose",
     },
     {
+      description: "mise-managed tool versions",
+      groupName: "mise tools",
+      matchManagers: ["mise"],
+      matchFileNames: [".mise.toml"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+    },
+    {
       description: "Barman Cloud Group",
       groupName: "Barman Cloud",
       matchDatasources: ["docker", "github-releases"],


### PR DESCRIPTION
## Summary
- Group Renovate updates detected by the mise manager into a single PR
- Limit the rule to `.mise.toml`

## Validation
- `npx --yes --package renovate renovate-config-validator .renovaterc.json5`