### PR TITLE
fix(cilium): repoint OCIRepository from deprecated charts-mirror to upstream

### DIFF
--- a/bootstrap/helmfile.yaml
+++ b/bootstrap/helmfile.yaml
@@ -9,7 +9,7 @@ helmDefaults:
 releases:
   - name: cilium
     namespace: kube-system
-    chart: oci://ghcr.io/home-operations/charts-mirror/cilium
+    chart: oci://quay.io/cilium/charts/cilium
     version: 1.18.6
     values: ['../kubernetes/apps/kube-system/cilium/app/helm/values.yaml']
 

--- a/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.18.6
-  url: oci://ghcr.io/home-operations/charts-mirror/cilium
+  url: oci://quay.io/cilium/charts/cilium


### PR DESCRIPTION
## Why

Renovate stopped offering Cilium bumps because our chart source is `ghcr.io/home-operations/charts-mirror/cilium`, which **deprecated Cilium on 2026-01-13** ([charts-mirror#388](https://github.com/home-operations/charts-mirror/pull/388), reason: *"Official OCI chart exists upstream"*). The mirror froze at **1.18.6**, and per its README policy deprecated charts are **pruned ~6 months after deprecation (~2026-07-13)** — after which `1.18.6` would 404 and break both Flux reconciliation **and a fresh cluster bootstrap**.

## What

Repoint the Cilium chart from the deprecated mirror to the upstream OCI chart **`oci://quay.io/cilium/charts/cilium`** in both places it's referenced:

- `kubernetes/apps/kube-system/cilium/app/ocirepository.yaml` (Flux, steady-state)
- `bootstrap/helmfile.yaml` (helmfile, pre-Flux cluster bootstrap)

Details:
- Verified upstream carries both `1.18.6` and `1.19.4`, with the same `application/vnd.cncf.helm.chart.content.v1.tar+gzip` layer mediaType the `layerSelector` expects.
- **Version stays at `1.18.6`** in both — chart content is identical, so this is a no-op registry switch (no Cilium behaviour change on merge).
- No `verify:`/cosign block existed, so nothing else changes.

## Follow-up (separate PR)

With the source repointed, Renovate will track upstream and raise the **1.18.6 → 1.19.4** bump (for both the OCIRepository and the bootstrap helmfile) on its own. 1.19.4 includes the BGP terminating-endpoint fix ([cilium/cilium#45276](https://github.com/cilium/cilium/issues/45276) / [#45286](https://github.com/cilium/cilium/pull/45286)) — Cilium now withdraws the LB BGP route when endpoints go *terminating* rather than after pods are deleted, closing the stale-next-hop / `connection refused` window we hit during node drains. Review against the [1.19 upgrade notes](https://docs.cilium.io/en/v1.19/operations/upgrade/) (BGP API is already on `cilium.io/v2` here, so the v1 `CiliumBGPPeeringPolicy` removal does not apply) before merging that bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)