### PR TITLE
fix(cilium): migrate CiliumLoadBalancerIPPool to cilium.io/v2 (1.19 prep)

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/network.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/network.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: pool


### PR DESCRIPTION
## Why

**Required prep for the Cilium 1.19 upgrade (#2796).** Cilium 1.19 **removes the `cilium.io/v2alpha1` served version of `CiliumLoadBalancerIPPool`**. Our pool is still declared as `v2alpha1`, so upgrading without this change would break LB-IPAM — every LoadBalancer VIP (`envoy-internal/external`, AdGuard DNS `10.0.88.53`, MQTT, Home Assistant, …) would lose its address.

## What

Bump the `CiliumLoadBalancerIPPool` manifest from `cilium.io/v2alpha1` → `cilium.io/v2`. Schema is unchanged (`allowFirstLastIPs`, `blocks`).

## Safety

Verified against the live cluster (still on 1.18.6):
- The CRD **already serves `v2` as the storage version** (`v2alpha1` is `storage=false`).
- A **server-side dry-run** of the pool as `cilium.io/v2` applies cleanly.

So this is a no-op API-version migration on 1.18.6 and is forward/backward compatible. **Merge this before #2796.** After Flux reconciles, confirm the pool still lists the `10.0.88.0/24` VIPs as allocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)