### PR TITLE
Add SparkFitness application deployment to Kubernetes cluster

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ./miniflux/ks.yaml
   - ./paperless-ngx/ks.yaml
   - ./readeck/ks.yaml
+  - ./sparkyfitness/ks.yaml

--- a/kubernetes/apps/default/sparkyfitness/app/externalsecret.yaml
+++ b/kubernetes/apps/default/sparkyfitness/app/externalsecret.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sparkyfitness
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: sparkyfitness-secret
+    template:
+      data:
+        # App - the init/migration user and the runtime app user share the same role
+        # to avoid needing CREATEROLE on the database user.
+        SPARKY_FITNESS_DB_USER: "{{ .SPARKYFITNESS_POSTGRES_USER }}"
+        SPARKY_FITNESS_DB_PASSWORD: "{{ .SPARKYFITNESS_POSTGRES_PASS }}"
+        SPARKY_FITNESS_APP_DB_USER: "{{ .SPARKYFITNESS_POSTGRES_USER }}"
+        SPARKY_FITNESS_APP_DB_PASSWORD: "{{ .SPARKYFITNESS_POSTGRES_PASS }}"
+        SPARKY_FITNESS_API_ENCRYPTION_KEY: "{{ .SPARKYFITNESS_API_ENCRYPTION_KEY }}"
+        BETTER_AUTH_SECRET: "{{ .SPARKYFITNESS_BETTER_AUTH_SECRET }}"
+        # Postgres Init
+        INIT_POSTGRES_DBNAME: sparkyfitness
+        INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local.
+        INIT_POSTGRES_USER: "{{ .SPARKYFITNESS_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .SPARKYFITNESS_POSTGRES_PASS }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: sparkyfitness
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "SPARKYFITNESS_$1"
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/default/sparkyfitness/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sparkyfitness/app/helmrelease.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app sparkyfitness
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      sparkyfitness:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.4.0@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7
+              pullPolicy: Always
+            envFrom: &envFrom
+              - secretRef:
+                  name: sparkyfitness-secret
+        containers:
+          app:
+            image:
+              repository: docker.io/codewithcj/sparkyfitness_server
+              tag: v0.16.6.3@sha256:b6a1395f02f793d61a7631b840153719a8d07e53fad32655126266b3769c4a97
+            envFrom: *envFrom
+            env:
+              TZ: ${TZ}
+              SPARKY_FITNESS_DB_HOST: postgres-rw.database.svc.cluster.local
+              SPARKY_FITNESS_DB_PORT: "5432"
+              SPARKY_FITNESS_DB_NAME: sparkyfitness
+              SPARKY_FITNESS_FRONTEND_URL: "https://sparkyfitness.${SECRET_DOMAIN}"
+              SPARKY_FITNESS_DISABLE_SIGNUP: "false"
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+          frontend:
+            image:
+              repository: docker.io/codewithcj/sparkyfitness
+              tag: v0.16.6.3@sha256:554feb804a1c1a2fe2f1b0a5870ad9b43864a4c34a1be4b74d66797147659187
+            env:
+              SPARKY_FITNESS_SERVER_HOST: localhost
+              SPARKY_FITNESS_SERVER_PORT: "3010"
+              SPARKY_FITNESS_FRONTEND_URL: "https://sparkyfitness.${SECRET_DOMAIN}"
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+    service:
+      app:
+        controller: sparkyfitness
+        ports:
+          http:
+            port: 80
+    route:
+      app:
+        hostnames:
+          - "sparkyfitness.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      uploads:
+        existingClaim: *app
+        advancedMounts:
+          sparkyfitness:
+            app:
+              - path: /app/SparkyFitnessServer/uploads

--- a/kubernetes/apps/default/sparkyfitness/app/kustomization.yaml
+++ b/kubernetes/apps/default/sparkyfitness/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/default/sparkyfitness/ks.yaml
+++ b/kubernetes/apps/default/sparkyfitness/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app sparkyfitness
+  namespace: &namespace default
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/default/sparkyfitness/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # no flux ks dependents
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 2Gi # uploads only; database lives in CloudNative-PG
+      VOLSYNC_KOPIA_SCHEDULE: "36 * * * *"
+      VOLSYNC_R2_SCHEDULE: "33 2 * * *"


### PR DESCRIPTION
## Summary
This PR adds a complete Kubernetes deployment for SparkFitness, a fitness tracking application, to the default namespace. The deployment includes both the backend server and frontend components with proper database initialization, secret management, and persistent storage configuration.

## Key Changes
- **HelmRelease Configuration**: Added Helm deployment for SparkFitness with dual containers (backend server and frontend UI) using the app-template chart
- **Database Initialization**: Configured postgres-init container to automatically initialize the SparkFitness database with proper credentials
- **Secret Management**: Added ExternalSecret resource to fetch credentials from 1Password, including database credentials, API encryption keys, and authentication secrets
- **Networking**: Configured HTTPRoute for internal access via `sparkyfitness.${SECRET_DOMAIN}` through the Envoy ingress controller
- **Persistent Storage**: Set up PVC for application uploads with VolSync backup integration (Kopia and R2 schedules)
- **Resource Limits**: Defined appropriate CPU and memory requests/limits for both backend (256Mi) and frontend (32Mi) containers
- **Flux Integration**: Added Kustomization resource with proper dependencies on external-secrets and rook-ceph, and registered in the default namespace kustomization

## Notable Implementation Details
- Backend and frontend containers share the same pod for simplified networking (localhost communication on port 3010)
- Database user configuration reuses the same credentials for both init and runtime to avoid requiring CREATEROLE permissions
- Liveness and readiness probes enabled on the backend container
- Auto-reload annotation configured for the Stakater reloader to watch for secret changes
- VolSync capacity set to 2Gi for uploads only, as the database is managed separately by CloudNative-PG

https://claude.ai/code/session_013Bz5nALRKoY1i2HN2p3xsY