### PR TITLE
feat(network): switch UniFi DNS webhook to home-operations

### DIFF
--- a/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
@@ -24,13 +24,11 @@ spec:
       name: webhook
       webhook:
         image:
-          repository: ghcr.io/kashalls/external-dns-unifi-webhook
-          tag: v0.9.0@sha256:22f4106f44a0b9ac3c97cf29bbfef93026c1164492152dc797a1d6dc86ddfbb5
+          repository: ghcr.io/home-operations/external-dns-unifi-webhook
+          tag: 0.10.1@sha256:fee92a9fc4a3dd100fc6c9b483bd3a17972ba044182e977f39f5e9e9fb580839
         env:
           - name: UNIFI_HOST
             value: "https://10.0.0.1"
-          - name: UNIFI_EXTERNAL_CONTROLLER
-            value: "false"
           - name: UNIFI_API_KEY
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Summary
- switch UniFi external-dns webhook image from `ghcr.io/kashalls` to `ghcr.io/home-operations`
- bump webhook to `0.10.1` with digest pin
- remove `UNIFI_EXTERNAL_CONTROLLER`, which was removed in the 0.10 API migration

## Validation
- `uvx check-jsonschema --schemafile https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json kubernetes/apps/network/external-dns/unifi/helmrelease.yaml`
- `kubectl kustomize kubernetes/apps/network/external-dns/unifi`
