### PR TITLE
fix(storage): deduplicate Ceph pool growth alert

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -29,6 +29,13 @@ spec:
       prometheusRuleOverrides:
         CephNodeDiskspaceWarning:
           disabled: true
+        # Rook v1.19.6 added the cluster label to Ceph metrics, which leaves
+        # stale 2d-range series without that label until Prometheus retention
+        # ages them out. Deduplicate the growth prediction before joining pool
+        # metadata so PrometheusRuleFailures does not fire during mgr rollouts.
+        CephPoolGrowthWarning:
+          expr: >-
+            (max by (cluster, pool_id, instance) (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5)) * on(cluster,pool_id, instance) group_right() ceph_pool_metadata) >= 95
     ingress:
       dashboard:
         ingressClassName: ""


### PR DESCRIPTION
## Summary
- override `CephPoolGrowthWarning` to deduplicate the 2d growth prediction before joining pool metadata
- prevents `PrometheusRuleFailures` from stale Ceph mgr series after the Rook v1.19.6 metric-label change and mgr rollout

## Validation
- `uvx check-jsonschema --schemafile https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml`
- `kubectl kustomize kubernetes/apps/rook-ceph/rook-ceph/cluster`
- `helm template rook-ceph-cluster oci://ghcr.io/rook/rook-ceph-cluster --version v1.19.6 -n rook-ceph -f <(yq '.spec.values' kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml)`
