### PR TITLE
fix(gdb): restore namespace manifests

### DIFF
--- a/kubernetes/apps/gdb/gdb/app/externalsecret.yaml
+++ b/kubernetes/apps/gdb/gdb/app/externalsecret.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gdb-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gdb-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # App
+        DB_HOST: "gdb-postgres-rw.gdb.svc.cluster.local"
+        DB_PORT: "5432"
+        DB_USER: "{{ .POSTGRES_USER }}"
+        DB_PASSWORD: "{{ .POSTGRES_PASS }}"
+        DB_NAME: "gdb"
+        STASH_API_KEY: "{{ .STASH_API_KEY }}"
+
+        # Postgres Init
+        INIT_POSTGRES_DBNAME: gdb
+        INIT_POSTGRES_HOST: gdb-postgres-rw.gdb.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .POSTGRES_PASS }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+
+        # scraper
+        DATABASE_URL: "postgresql://{{ .POSTGRES_USER }}:{{ .POSTGRES_PASS }}@gdb-postgres-rw.gdb.svc.cluster.local:5432/gdb?sslmode=disable"
+        DATABASE_REPLICA_URL: "postgresql://{{ .POSTGRES_USER }}:{{ .POSTGRES_PASS }}@gdb-postgres-ro.gdb.svc.cluster.local:5432/gdb?sslmode=disable"
+
+  dataFrom:
+    - extract:
+        key: gdb
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/gdb/gdb/app/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/app/helmrelease.yaml
@@ -1,0 +1,114 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app gdb
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-private
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: *app
+    controllers:
+      gdb:
+        replicas: 1
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: 'true'
+        initContainers:
+          01-init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.3.0@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
+            envFrom:
+              - secretRef:
+                  name: gdb-secret
+        containers:
+          app:
+            image:
+              repository: ghcr.io/adampetrovic/gdb-web
+              tag: 1.10.20@sha256:dc7a87216d3508a896297785bf06001ae30ebf34ee6d98562cc8c296b5383afe
+              pullPolicy: Always
+            env:
+              SERVER_HOST: "0.0.0.0"
+              SERVER_PORT: "8080"
+              APP_ENV: "production"
+              LOG_LEVEL: "info"
+              CACHE_TTL: "30m"
+              RATE_LIMIT_PER_MIN: "600"
+              SERVER_READ_TIMEOUT: "60s"
+              SERVER_WRITE_TIMEOUT: "60s"
+              MEDIA_DIR: /media/g
+              STASH_HOST: http://stash-app.media.svc.cluster.local:9999
+              STASH_EXTERNAL_URL: https://stash.${SECRET_DOMAIN}
+            envFrom:
+              - secretRef:
+                  name: gdb-secret
+            resources:
+              requests:
+                cpu: 223m
+                memory: 100Mi
+              limits:
+                memory: 1Gi
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+    service:
+      app:
+        controller: gdb
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - gdb.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      media:
+        type: nfs
+        server: ${SECRET_NFS_DOMAIN}
+        path: /volume2/stash/media/g
+        globalMounts:
+          - path: /media/g

--- a/kubernetes/apps/gdb/gdb/app/kustomization.yaml
+++ b/kubernetes/apps/gdb/gdb/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/gdb/gdb/database/cluster.yaml
+++ b/kubernetes/apps/gdb/gdb/database/cluster.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: gdb-postgres
+  annotations:
+    cnpg.io/skipEmptyWalArchiveCheck: "enabled"
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgis:17-3.5
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: 40Gi
+    storageClass: openebs-hostpath
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: gdb-postgres-secret
+  postgresql:
+    parameters:
+      max_connections: "600"
+      shared_buffers: 512MB
+    #shared_preload_libraries:
+    #  - "vectors.so"
+  nodeMaintenanceWindow:
+    inProgress: false
+    reusePVC: true
+  # https://github.com/cloudnative-pg/cloudnative-pg/issues/2570
+  enablePDB: false
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1536Mi
+    limits:
+      memory: 3Gi
+  monitoring:
+    enablePodMonitor: true
+    podMonitorMetricRelabelings:
+      - { sourceLabels: ["cluster"], targetLabel: cnpg_cluster, action: replace }
+      - { regex: cluster, action: labeldrop }
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters: &parameters
+        barmanObjectName: gdb-garage
+        serverName: gdb-postgres
+  bootstrap:
+    recovery:
+      source: source
+  externalClusters:
+    - name: source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters: *parameters

--- a/kubernetes/apps/gdb/gdb/database/externalsecret.yaml
+++ b/kubernetes/apps/gdb/gdb/database/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gdb-postgres-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gdb-postgres-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: cloudnative-pg
+        property: POSTGRES_SUPER_USER
+    - secretKey: password
+      remoteRef:
+        key: cloudnative-pg
+        property: POSTGRES_SUPER_PASS
+    - secretKey: aws-access-key-id
+      remoteRef:
+        key: cloudnative-pg
+        property: AWS_ACCESS_KEY_ID
+    - secretKey: aws-secret-access-key
+      remoteRef:
+        key: cloudnative-pg
+        property: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/gdb/gdb/database/kustomization.yaml
+++ b/kubernetes/apps/gdb/gdb/database/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml
+  - ./externalsecret.yaml
+  - ./objectstore.yaml
+  - ./scheduledbackup.yaml
+  - ./service.yaml

--- a/kubernetes/apps/gdb/gdb/database/objectstore.yaml
+++ b/kubernetes/apps/gdb/gdb/database/objectstore.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://schemas.hydaz.com/barmancloud.cnpg.io/objectstore_v1.json
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: gdb-garage
+spec:
+  retentionPolicy: 7d
+  configuration:
+    destinationPath: s3://postgres/
+    endpointURL: https://s3.${SECRET_DOMAIN}
+    s3Credentials:
+      accessKeyId:
+        name: gdb-postgres-secret
+        key: aws-access-key-id
+      secretAccessKey:
+        name: gdb-postgres-secret
+        key: aws-secret-access-key
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    data:
+      compression: bzip2

--- a/kubernetes/apps/gdb/gdb/database/scheduledbackup.yaml
+++ b/kubernetes/apps/gdb/gdb/database/scheduledbackup.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: gdb-postgres
+spec:
+  schedule: "@daily"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: gdb-postgres
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/gdb/gdb/database/service.yaml
+++ b/kubernetes/apps/gdb/gdb/database/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gdb-postgres
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: gdb-postgres.${SECRET_DOMAIN}
+    io.cilium/lb-ipam-ips: 10.0.81.15
+spec:
+  type: LoadBalancer
+  ports:
+    - name: gdb-postgres
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    cnpg.io/cluster: gdb-postgres
+    role: primary

--- a/kubernetes/apps/gdb/gdb/ks.yaml
+++ b/kubernetes/apps/gdb/gdb/ks.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gdb
+spec:
+  targetNamespace: gdb
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: gdb-postgres-cluster
+      namespace: gdb
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/gdb/gdb/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gdb-scraper
+spec:
+  targetNamespace: gdb
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: gdb-postgres-cluster
+      namespace: gdb
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/gdb/gdb/scraper
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gdb-postgres-cluster
+spec:
+  targetNamespace: gdb
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: database
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/gdb/gdb/database
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -1,0 +1,127 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gdb-scraper
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-private
+    controllers:
+      mms:
+        type: cronjob
+        cronjob:
+          schedule: "0 6 * * 1"      # Monday 6am AEST
+          timeZone: "Australia/Sydney"
+          suspend: false
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        containers:
+          scraper:
+            image: &image
+              repository: ghcr.io/adampetrovic/gdb-scraper
+              tag: 0.1.52@sha256:bcf102958ae24b3c22781eede7010db564837080099ce7fba649fd26d2ac8444
+            envFrom:
+              - secretRef:
+                  name: gdb-secret
+            env:
+              OUTPUT_DIR: /export
+              MODE: incremental
+              SOURCE: mms
+            resources:
+              requests:
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+        pod:
+          restartPolicy: Never
+          securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            supplementalGroups: [100]
+      mso:
+        type: cronjob
+        cronjob:
+          schedule: "0 18 * * 3"      # Wednesday 6pm AEST
+          timeZone: "Australia/Sydney"
+          suspend: false
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        containers:
+          scraper:
+            image: *image
+            envFrom:
+              - secretRef:
+                  name: gdb-secret
+            env:
+              OUTPUT_DIR: /export
+              MODE: incremental
+              SOURCE: mso
+            resources:
+              requests:
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+        pod:
+          restartPolicy: Never
+          securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            supplementalGroups: [100]
+      usag:
+        type: cronjob
+        cronjob:
+          schedule: "0 12 * * 0"      # Sunday 12pm AEST
+          timeZone: "Australia/Sydney"
+          suspend: false
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        containers:
+          scraper:
+            image: *image
+            envFrom:
+              - secretRef:
+                  name: gdb-secret
+            env:
+              OUTPUT_DIR: /export
+              MODE: incremental
+              SOURCE: usag
+            resources:
+              requests:
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+        pod:
+          restartPolicy: Never
+          securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            supplementalGroups: [100]
+    persistence:
+      export:
+        existingClaim: gdb-scraper

--- a/kubernetes/apps/gdb/gdb/scraper/kustomization.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/gdb/gdb/scraper/pvc.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gdb-scraper
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-filesystem

--- a/kubernetes/apps/gdb/kustomization.yaml
+++ b/kubernetes/apps/gdb/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gdb
+components:
+  - ../../components/common
+resources:
+  - ./gdb/ks.yaml


### PR DESCRIPTION
## Summary
- restore the missing `gdb` namespace GitOps tree from the saved worktree copy
- enable CNPG bootstrap recovery from the existing Barman object-store backup

## Validation
- `kubectl kustomize kubernetes/apps/gdb`
- `kubectl kustomize kubernetes/apps/gdb/gdb/app`
- `kubectl kustomize kubernetes/apps/gdb/gdb/database`
- `kubectl kustomize kubernetes/apps/gdb/gdb/scraper`
- `flux build kustomization cluster-apps -n flux-system --path ./kubernetes/apps --local-sources GitRepository/flux-system/flux-system=.`
- schema validation with `uvx check-jsonschema` for all recovered schema-backed YAML files
