### PR TITLE
fix(gdb): start postgres empty when no backup exists

### DIFF
--- a/kubernetes/apps/gdb/gdb/database/cluster.yaml
+++ b/kubernetes/apps/gdb/gdb/database/cluster.yaml
@@ -44,9 +44,9 @@ spec:
       parameters: &parameters
         barmanObjectName: gdb-garage
         serverName: gdb-postgres
-  bootstrap:
-    recovery:
-      source: source
+#  bootstrap:
+#    recovery:
+#      source: source
   externalClusters:
     - name: source
       plugin:


### PR DESCRIPTION
## Summary
- stop bootstrapping `gdb-postgres` from Barman during namespace recovery
- the gdb Barman catalog is empty (`no target backup found`), so recovery jobs loop forever
- this lets CNPG create an empty primary so the namespace can finish recovering

## Validation
- `kubectl kustomize kubernetes/apps/gdb/gdb/database`
- `uvx check-jsonschema --schemafile https://homelab-schemas-epg.pages.dev/postgresql.cnpg.io/cluster_v1.json kubernetes/apps/gdb/gdb/database/cluster.yaml`
