### PR TITLE
feat(gdb): bump gdb-scraper image to 0.1.78 for apparatus/AA scores

### DIFF
--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
           scraper:
             image: &image
               repository: ghcr.io/adampetrovic/gdb-scraper
-              tag: 0.1.77@sha256:4424d456eea5361f8419a2a90506453c50a8da2a3d3374ea1899278667ff3d0f
+              tag: 0.1.78@sha256:2fdefa1a13f5f7fe7c882bab253410f9bb42818cb256af766b913126255a399f
             envFrom: &envFrom
               - secretRef:
                   name: gdb-secret


### PR DESCRIPTION
Bumps the `gdb-scraper` image to **0.1.78** — the version that persists apparatus + all-around scores (adampetrovic/gdb-scraper#2, merged). Digest pinned to the published image (`sha256:2fdefa1a…399f`).

## Prerequisite before any scraper job runs
gdb-web migration **000043** (adampetrovic/gdb-web#3, merged) adds the `aa/vault/bars/beam/floor` columns and must be **applied** to the live DB first — `_upsert_result` rolls back on the missing columns otherwise. The deployed gdb-web image predates the migration, so apply it via a new gdb-web image deploy or `make migrate-up`.

## Safety
- All `gdb-scraper` CronJobs are `suspend: true`, so merging this changes the pinned image but runs nothing until a Job is created/unsuspended.
- Backfill (`mso-bootstrap-replay-cache`) is run manually **after** the in-flight bootstrap fetch/usag jobs finish — not part of this PR.

Refs: adampetrovic/gdb-web#3, adampetrovic/gdb-scraper#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)