### PR TITLE
fix(homebox): add api key pepper secret

### DIFF
--- a/kubernetes/apps/default/homebox/app/externalsecret.yaml
+++ b/kubernetes/apps/default/homebox/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homebox
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: homebox-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        HBOX_AUTH_API_KEY_PEPPER: "{{ .HBOX_AUTH_API_KEY_PEPPER }}"
+  dataFrom:
+    - extract:
+        key: homebox

--- a/kubernetes/apps/default/homebox/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homebox/app/helmrelease.yaml
@@ -46,6 +46,9 @@ spec:
               HBOX_MAILER_FROM: homebox@${SECRET_DOMAIN}
               HBOX_MAILER_USERNAME: unused
               HBOX_MAILER_PASSWORD: unused
+            envFrom:
+              - secretRef:
+                  name: homebox-secret
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/default/homebox/app/kustomization.yaml
+++ b/kubernetes/apps/default/homebox/app/kustomization.yaml
@@ -3,4 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary
- add ExternalSecret for Homebox API key pepper
- inject homebox-secret into the Homebox HelmRelease

## Validation
- uvx check-jsonschema --schemafile https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json kubernetes/apps/default/homebox/app/externalsecret.yaml
- uvx check-jsonschema --schemafile https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json kubernetes/apps/default/homebox/app/helmrelease.yaml
- uvx check-jsonschema --schemafile https://json.schemastore.org/kustomization kubernetes/apps/default/homebox/app/kustomization.yaml

## Notes
- 1Password item `homebox` with concealed field `HBOX_AUTH_API_KEY_PEPPER` has been created in vault `k8s`.
- Required before merging Homebox 0.26 Renovate PR.