### PR TITLE
fix(observability): stop Vector log replay after upgrade

### DIFF
--- a/kubernetes/apps/media/plex/app/config/vector.yaml
+++ b/kubernetes/apps/media/plex/app/config/vector.yaml
@@ -1,10 +1,11 @@
 data_dir: /vector-data-dir
+timezone: Australia/Sydney
 sources:
   plex_logs:
     type: file
     include:
       - /config/Library/Application Support/Plex Media Server/Logs/Plex Media Server.log
-    read_from: beginning
+    read_from: end
     ignore_older_secs: 600
     multiline:
       start_pattern: '^\w{3} \d{2}, \d{4} \d{2}:\d{2}:\d{2}'

--- a/kubernetes/apps/observability/vector/app/agent/resources/vector.yaml
+++ b/kubernetes/apps/observability/vector/app/agent/resources/vector.yaml
@@ -4,6 +4,7 @@ data_dir: /vector-data-dir
 sources:
   kubernetes_source:
     type: kubernetes_logs
+    read_from: end
     use_apiserver_cache: true
     pod_annotation_fields:
       container_image: container_image


### PR DESCRIPTION
## Summary
- set Vector Kubernetes log source to start new files at the end after restarts
- set Plex Vector source to start at the end after sidecar restarts
- parse Plex local timestamps with Australia/Sydney so Loki does not reject them as future timestamps

## Validation
- `yq e .` on changed Vector YAML files
- `vector validate --dangerously-allow-env-var-interpolation` against live Vector 0.57 for agent config
- `vector validate --dangerously-allow-env-var-interpolation` against live Vector 0.57 for Plex config
- `vector vrl -z Australia/Sydney` confirmed Plex local time maps to UTC correctly

## Rollout context
Vector 0.57 rollout exposed Loki timestamp rejections from replayed old logs and Plex local timestamps parsed as UTC. This PR is a fix-forward before continuing with Paperless v3.