### PR TITLE
fix(system-upgrade): make Tuppr Talos rollouts volume-aware

### DIFF
--- a/.pi/skills/renovate-merge/AGENTS.md
+++ b/.pi/skills/renovate-merge/AGENTS.md
@@ -1,0 +1,64 @@
+# Renovate Merge Skill Agent Instructions
+
+These rules are mandatory for agents using the `renovate-merge` skill in `home-ops`.
+
+## Talos Renovate PRs are isolated maintenance
+
+Do **not** include Talos Linux Renovate PRs in a bulk merge wave. Treat every Talos installer update as a single-purpose maintenance rollout because it reboots nodes and can affect Ceph, CNPG/Postgres, Cilium, Envoy/Gateway API, LoadBalancer routing, and Tuppr state.
+
+For Talos PRs:
+
+1. Merge only the Talos PR, after explicit user approval.
+2. Do not merge Cilium, cert-manager, Flux Operator, Rook-Ceph, Kubernetes, or leaf-app PRs in the same wave.
+3. Before merge/rollout, verify:
+   - all nodes are `Ready` and schedulable
+   - Ceph is `HEALTH_OK`
+   - no pods are non-running/non-succeeded
+   - no VolSync `ReplicationSource` is actively `Synchronizing=True`
+   - `TalosUpgrade/talos` is not already `Failed`
+4. After rollout, verify:
+   - every node reports the target Talos version, kernel, and containerd version
+   - all nodes are Ready and schedulable
+   - Ceph is `HEALTH_OK`
+   - no non-running pods remain
+   - no stale `tuppr.home-operations.com/outdated` taints remain
+   - Flux Kustomizations and HelmReleases are Ready
+   - BGP/LoadBalancer sanity for services with `externalTrafficPolicy: Local`
+5. Only after this is clean may remaining Renovate PRs be considered.
+
+## Tuppr-specific guidance
+
+Before relying on newer Tuppr policy fields, verify the CRD is current. Flux HelmRelease must use CRD replacement on install and upgrade:
+
+```yaml
+spec:
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+```
+
+Without this, Helm may leave old CRDs installed; the controller can run a newer version while Kubernetes prunes/rejects newer spec/status fields.
+
+Preferred Tuppr policy for automated Talos rollouts:
+
+```yaml
+spec:
+  policy:
+    rebootMode: powercycle
+    waitForVolumeDetach: true
+```
+
+`waitForVolumeDetach` makes Tuppr drain first, wait for CSI `VolumeAttachment`s to clear, then run `talosctl upgrade --drain=false`. This avoids the failure mode where Talos installs successfully but `talosctl` drain times out before reboot.
+
+Caveat: Tuppr currently hardcodes its own drain timeout at 10 minutes and has no configurable `drainTimeout` field. CNPG/Postgres pods in this cluster may have `terminationGracePeriodSeconds: 1800`, so control-plane/CNPG-heavy nodes can still exceed Tuppr's drain window. For those rollouts, prefer manual `talosctl upgrade --drain-timeout=35m --reboot-mode=powercycle`, or ask the user before using `policy.nodrain: true`.
+
+## If Tuppr fails mid-Talos rollout
+
+If logs show `installation of <target> complete` / `Exit code: 0` but the node stays on the old Talos version:
+
+1. Recover full Tuppr job logs from Loki before taking more action.
+2. Verify whether the node installed the target but failed before reboot.
+3. If confirmed, manually reboot the node with Talos (`powercycle`), then monitor Kubernetes and Ceph.
+4. Reset Tuppr with its documented reset annotation only after all nodes are healthy or intentionally halted.
+5. Remove/verify stale `tuppr.home-operations.com/outdated` taints only after the controller has had a chance to reconcile.

--- a/.pi/skills/renovate-merge/SKILL.md
+++ b/.pi/skills/renovate-merge/SKILL.md
@@ -7,7 +7,7 @@ description: Bulk-merge open Renovate PRs safely. Analyses breaking changes, fet
 
 Bulk-merge open Renovate dependency-update PRs with breaking-change analysis, a dependency-ordered rollout plan, and post-merge cluster health monitoring.
 
-Read the [merge playbook](references/playbook.md) for the full procedure. The sections below are a quick reference.
+Read [AGENTS.md](AGENTS.md) first for mandatory home-ops Renovate rollout rules, then read the [merge playbook](references/playbook.md) for the full procedure. The sections below are a quick reference.
 
 ## Quick Reference
 

--- a/.pi/skills/renovate-merge/references/playbook.md
+++ b/.pi/skills/renovate-merge/references/playbook.md
@@ -10,6 +10,8 @@ This is a three-phase workflow:
 2. **Plan** — Build a dependency-ordered merge plan with user approval gates
 3. **Roll out** — Execute the plan wave-by-wave with cluster health checks
 
+Critical platform rule: Talos Linux PRs are **not** bulk-wave items. Treat them as isolated maintenance rollouts; merge no other Renovate PRs until every node, Ceph, Flux, and LoadBalancer sanity check is clean.
+
 ---
 
 ## Phase 1: Analyse
@@ -95,8 +97,8 @@ Output a summary table:
 
 **Always require explicit user approval before merging:**
 
-1. **Talos Linux** updates (node OS — requires rolling reboot of all nodes)
-2. **Kubernetes** version bumps (control plane + kubelet upgrade)
+1. **Talos Linux** updates (node OS — requires isolated maintenance rollout and rolling reboot of all nodes)
+2. **Kubernetes** version bumps (control plane + kubelet upgrade; usually isolate like Talos)
 3. **Cilium** updates (CNI — brief network disruption possible)
 4. **Rook-Ceph** updates (storage — data plane risk)
 5. **Flux Operator** updates (GitOps engine — reconciliation disruption)
@@ -105,13 +107,25 @@ Output a summary table:
 
 Present these to the user with the breaking change analysis and wait for confirmation before including them in the rollout.
 
+### Talos-specific rollout rule
+
+Do not merge Talos PRs as part of a bulk update wave. Talos changes reboot nodes and can disturb Ceph, CNPG/Postgres, Cilium, Envoy, LoadBalancer routing, and Tuppr state. A Talos PR must be planned as a single-purpose rollout:
+
+1. Precheck: all nodes Ready/schedulable, Ceph `HEALTH_OK`, no active VolSync syncs, no non-running pods, and `TalosUpgrade/talos` not already `Failed`.
+2. Merge only the Talos PR after explicit user approval.
+3. Monitor Tuppr/manual rollout to completion.
+4. Verify every node is on the target Talos/kernel/containerd, Ceph is `HEALTH_OK`, Flux is Ready, no stale `tuppr.home-operations.com/outdated` taints remain, and LoadBalancer/BGP sanity is clean.
+5. Only then resume other Renovate PRs.
+
+Before relying on newer Tuppr policy fields, confirm the Tuppr HelmRelease upgrades CRDs with `install.crds: CreateReplace` and `upgrade.crds: CreateReplace`; otherwise the controller may be newer than the CRD schema. Prefer `spec.policy.waitForVolumeDetach: true` for Tuppr Talos rollouts, but remember Tuppr currently hardcodes its own drain timeout to 10 minutes. CNPG/Postgres pods can have `terminationGracePeriodSeconds: 1800`; for CNPG-heavy/control-plane nodes, prefer manual `talosctl upgrade --drain-timeout=35m --reboot-mode=powercycle`, or ask the user before using `policy.nodrain: true`.
+
 ### Merge Waves
 
-Order merges by dependency depth — infrastructure first, leaf apps last. Allow 30-60 seconds between waves for Flux to reconcile via webhook.
+Order merges by dependency depth — infrastructure first, leaf apps last. Allow 30-60 seconds between waves for Flux to reconcile via webhook. Talos is excluded from ordinary waves; Kubernetes version bumps should also be isolated unless the user explicitly approves otherwise.
 
 | Wave | Tier | Components | Why first |
 |------|------|-----------|-----------|
-| **1** | Platform | Talos, Kubernetes (via Tuppr), Cilium | Node-level, everything depends on these |
+| **1** | Platform | Cilium | Cluster networking; everything depends on it |
 | **2** | Infrastructure | cert-manager, Flux, External Secrets (1Password), Rook-Ceph, OpenEBS | Cluster services that apps depend on |
 | **3** | Storage & Backup | VolSync (chart + image together), CloudNativePG, Dragonfly | Data layer |
 | **4** | Observability | Prometheus stack, Loki, Vector (all instances grouped), Grafana | Log/metric pipeline — merge Loki before Vector |
@@ -219,6 +233,16 @@ If a health check shows problems after a wave:
 3. Check if it's **transient** (e.g. `KubeDeploymentReplicasMismatch` during a rolling update — these resolve within ~5 minutes) vs **persistent** (e.g. CrashLoopBackOff, failed Helm upgrade).
 4. For transient issues: wait 2-3 minutes and re-check before escalating.
 5. For persistent issues: the user needs to decide whether to fix-forward or revert.
+
+#### Talos/Tuppr partial failure handling
+
+If Tuppr fails a Talos rollout, stop all remaining Renovate activity. Recover full Tuppr job logs first. If logs show `installation of <target> complete` / `Exit code: 0` but the node did not reboot and still reports the old Talos version, the likely failure point is post-install drain. In that case:
+
+1. Verify cluster/Ceph health and whether the node is cordoned or tainted.
+2. If the target was installed but not booted, manually reboot that node with Talos `powercycle` and monitor it back to Ready.
+3. Wait for Ceph `HEALTH_OK`, no non-running pods, and no active VolSync syncs before touching another node.
+4. Reset Tuppr with the documented reset annotation only after all nodes are upgraded/healthy or the rollout is intentionally halted.
+5. Verify stale `tuppr.home-operations.com/outdated` taints are gone before resuming Renovate merges.
 
 ### 3.6 Transient alerts to expect
 

--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -10,9 +10,11 @@ spec:
     kind: OCIRepository
     name: tuppr
   install:
+    crds: CreateReplace
     remediation:
       retries: -1
   upgrade:
+    crds: CreateReplace
     cleanupOnFail: true
     remediation:
       strategy: rollback

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -10,6 +10,7 @@ spec:
     version: v1.13.7
   policy:
     rebootMode: powercycle
+    waitForVolumeDetach: true
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource


### PR DESCRIPTION
## Summary
- keep Tuppr CRDs upgraded via Flux HelmRelease `CreateReplace` on install/upgrade
- enable `policy.waitForVolumeDetach` on the TalosUpgrade so Tuppr owns drain, waits for CSI detach, then runs `talosctl upgrade --drain=false`
- document Talos/Tuppr rollout guardrails in the renovate-merge skill

## Validation
- `uvx check-jsonschema --schemafile https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml`
- `uvx check-jsonschema --schemafile /tmp/tuppr-validate/talosupgrade_v1alpha1.schema.yaml kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml`
- `kustomize build kubernetes/apps/system-upgrade/tuppr/app`
- `kustomize build kubernetes/apps/system-upgrade/tuppr/upgrades`

Note: the public kubernetes-schemas Tuppr schema is stale for `waitForVolumeDetach`, so TalosUpgrade validation used the CRD bundled in the Tuppr 0.4.0 chart.
