### PR TITLE
fix(network): restore SMTP relay delivery

### DIFF
--- a/kubernetes/apps/network/smtp-relay/app/config/maddy.conf
+++ b/kubernetes/apps/network/smtp-relay/app/config/maddy.conf
@@ -26,8 +26,7 @@ target.queue remote_queue {
 
 target.smtp remote_smtp {
     debug {env:DEBUG}
-    attempt_starttls no
-    require_tls no
+    starttls yes
     auth off
     targets tcp://{env:SMTP_SERVER}:{env:SMTP_PORT}
 }


### PR DESCRIPTION
## Summary
- require STARTTLS for Maddy's Google Workspace SMTP relay connection
- pair the GitOps change with the relay port update from TCP/25 to TCP/587 in 1Password

## Root cause
Outbound TCP/25 returns `no route to host`, causing Maddy to treat queued messages as permanently undeliverable and remove them. Google Workspace documents TCP/587 with TLS for SMTP relay, and TCP/587 is reachable from the network.

## Validation
- `kubectl kustomize kubernetes/apps/network/smtp-relay/app`
- verified `smtp-relay.gmail.com:25` is unreachable
- verified `smtp-relay.gmail.com:587` is reachable
- verified the `k8s/smtp-relay` 1Password item now uses port `587`
