### PR TITLE
feat(automation): deploy Garmin data collector

### DIFF
--- a/kubernetes/apps/automation/garmin-grafana/README.md
+++ b/kubernetes/apps/automation/garmin-grafana/README.md
@@ -1,0 +1,40 @@
+# Garmin Grafana Collector
+
+Fetches Garmin Connect health and activity data into the existing InfluxDB deployment for visualization in Grafana.
+
+## Data path
+
+- Collector namespace: `automation`
+- InfluxDB endpoint: `influxdb.observability.svc.cluster.local:8086`
+- InfluxDB bucket: `garmin`
+- InfluxQL DBRP: `GarminStats/autogen`
+- Garmin OAuth token storage: `/home/appuser/.garminconnect` on the `garmin-grafana` PVC
+
+The collector uses InfluxDB 2's authenticated v1 compatibility API. Its v1-compatible credential requires read and write access because the collector queries the latest `HeartRateIntraday` point before fetching updates.
+
+## Garmin authentication bootstrap
+
+Garmin OAuth tokens must be generated interactively before the collector is enabled. Keep `controllers.garmin-grafana.replicas` at `0` until the PVC exists and token bootstrap is complete.
+
+Use a temporary interactive pod with the same image, UID/GID, InfluxDB secret, and `garmin-grafana` PVC. Generate the Garmin session in `/home/appuser/.garminconnect`, then delete the pod immediately. Do not store the Garmin password in Git, Kubernetes, or 1Password solely for steady-state operation.
+
+Repeated unauthenticated restarts can trigger multiple MFA prompts and Garmin rate limiting. Scale the collector back to zero before renewing an expired session.
+
+## Backfill
+
+The normal collector defaults to a seven-day initial fetch. For older history, run a separate one-off pod with `MANUAL_START_DATE` and optional `MANUAL_END_DATE`. Do not set batch-mode dates on the permanent Deployment because the process exits when the backfill finishes.
+
+## Operations
+
+```bash
+# Collector and secret state
+kubectl get hr,externalsecret,pod -n automation -l app.kubernetes.io/name=garmin-grafana
+
+# Recent logs
+kubectl logs -n automation deploy/garmin-grafana --tail=200
+
+# Snapshot Garmin OAuth tokens
+task volsync:snapshot app=garmin-grafana ns=automation
+```
+
+The OAuth token files are sensitive and are included in encrypted Kopia and R2 VolSync backups.

--- a/kubernetes/apps/automation/garmin-grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/automation/garmin-grafana/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garmin-grafana
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: garmin-grafana-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: INFLUXDB_USERNAME
+      remoteRef:
+        key: garmin-grafana
+        property: INFLUXDB_USERNAME
+    - secretKey: INFLUXDB_PASSWORD
+      remoteRef:
+        key: garmin-grafana
+        property: INFLUXDB_PASSWORD

--- a/kubernetes/apps/automation/garmin-grafana/app/grafanadashboard.yaml
+++ b/kubernetes/apps/automation/garmin-grafana/app/grafanadashboard.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: garmin-grafana
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  datasources:
+    - datasourceName: Garmin InfluxDB
+      inputName: DS_GARMIN_STATS
+  url: https://raw.githubusercontent.com/arpanghosh8453/garmin-grafana/8e47830364817bc1a355eab857fa0535a99d401f/Grafana_Dashboard/Garmin-Grafana-Dashboard.json

--- a/kubernetes/apps/automation/garmin-grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/garmin-grafana/app/helmrelease.yaml
@@ -1,0 +1,88 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app garmin-grafana
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 2
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      garmin-grafana:
+        # Keep disabled until Garmin OAuth tokens have been bootstrapped into the PVC.
+        replicas: 0
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/arpanghosh8453/garmin-fetch-data
+              tag: latest@sha256:3282b5144f23a8b9e96e4593a03f50914add28c5d837e4ef529781d45ee7cba7
+            env:
+              TZ: "${TZ}"
+              INFLUXDB_VERSION: "1"
+              INFLUXDB_HOST: influxdb.observability.svc.cluster.local
+              INFLUXDB_PORT: "8086"
+              INFLUXDB_DATABASE: GarminStats
+              INFLUXDB_ENDPOINT_IS_HTTP: "true"
+              TOKEN_DIR: /home/appuser/.garminconnect
+              USER_TIMEZONE: Australia/Sydney
+              UPDATE_INTERVAL_SECONDS: "300"
+              FORCE_REPROCESS_ACTIVITIES: "false"
+              TAG_MEASUREMENTS_WITH_USER_EMAIL: "false"
+              REQUEST_INTRADAY_DATA_REFRESH: "false"
+            envFrom:
+              - secretRef:
+                  name: garmin-grafana-secret
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+    persistence:
+      tokens:
+        enabled: true
+        existingClaim: *app
+        advancedMounts:
+          garmin-grafana:
+            app:
+              - path: /home/appuser/.garminconnect
+      tmp:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/automation/garmin-grafana/app/kustomization.yaml
+++ b/kubernetes/apps/automation/garmin-grafana/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/automation/garmin-grafana/ks.yaml
+++ b/kubernetes/apps/automation/garmin-grafana/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garmin-grafana
+  namespace: &namespace automation
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: influxdb
+      namespace: observability
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/automation/garmin-grafana/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # no flux ks dependents
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_KOPIA_SCHEDULE: "50 * * * *"
+      VOLSYNC_R2_SCHEDULE: "15 1 * * *"

--- a/kubernetes/apps/automation/kustomization.yaml
+++ b/kubernetes/apps/automation/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./esphome/ks.yaml
   - ./fernwood-booker/ks.yaml
   - ./frigate/ks.yaml
+  - ./garmin-grafana/ks.yaml
   - ./go2rtc/ks.yaml
   - ./go2rtc-split/ks.yaml
   - ./home-assistant/ks.yaml

--- a/kubernetes/apps/observability/grafana/instance/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/instance/externalsecret.yaml
@@ -22,6 +22,12 @@ spec:
         TESLAMATE_POSTGRES_PASS: "{{ .TESLAMATE_POSTGRES_PASS }}"
         GRAFANA_INFLUXDB_TOKEN: "{{ .GRAFANA_INFLUXDB_TOKEN }}"
         INFLUXDB_ORG_ID: "{{ .ORG_ID }}"
+        GARMIN_INFLUXDB_AUTH_HEADER: "Token {{ .GARMIN_INFLUXDB_TOKEN }}"
+  data:
+    - secretKey: GARMIN_INFLUXDB_TOKEN
+      remoteRef:
+        key: garmin-grafana
+        property: GRAFANA_INFLUXDB_TOKEN
   dataFrom:
     - extract:
         key: grafana

--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
@@ -90,6 +90,35 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:
+  name: garmin-influxdb
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  valuesFrom:
+    - targetPath: "secureJsonData.httpHeaderValue1"
+      valueFrom:
+        secretKeyRef:
+          name: grafana-secret
+          key: GARMIN_INFLUXDB_AUTH_HEADER
+  datasource:
+    type: influxdb
+    name: Garmin InfluxDB
+    uid: garmin-influxdb
+    access: proxy
+    url: http://influxdb.observability.svc.cluster.local:8086
+    isDefault: false
+    jsonData:
+      dbName: GarminStats
+      httpMode: POST
+      httpHeaderName1: Authorization
+    secureJsonData:
+      httpHeaderValue1: "$${GARMIN_INFLUXDB_AUTH_HEADER}"
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadatasource_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
   name: teslamate
 spec:
   instanceSelector:


### PR DESCRIPTION
## Summary
- deploy the Garmin Connect collector in `automation`, initially scaled to zero for interactive OAuth bootstrap
- persist Garmin session tokens with VolSync and write through InfluxDB 2's v1 compatibility API
- add a least-privilege InfluxQL Grafana datasource and the pinned upstream Garmin dashboard

## Provisioning completed
- created the `garmin` InfluxDB bucket and `GarminStats/autogen` DBRP mapping
- created a read/write v1 collector authorization and read-only Grafana token
- stored the credentials in the `garmin-grafana` 1Password item

## Validation
- schema validation passed for all changed YAML
- Kustomize builds passed for automation and the Grafana instance
- Kubernetes server-side dry-run passed for the new resources
- `flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose` — 212 passed
- verified collector compatibility read/write, Grafana read access, and Grafana write denial

## Rollout
After merge, Flux will provision the PVC and supporting resources while the collector remains at zero replicas. Garmin OAuth/MFA bootstrap and the one-replica enablement will follow separately.
