### PR TITLE
feat(automation): enable Garmin data collector

### DIFF
--- a/kubernetes/apps/automation/garmin-grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/garmin-grafana/app/helmrelease.yaml
@@ -23,8 +23,7 @@ spec:
   values:
     controllers:
       garmin-grafana:
-        # Keep disabled until Garmin OAuth tokens have been bootstrapped into the PVC.
-        replicas: 0
+        replicas: 1
         strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Summary
- enable the Garmin collector after interactive OAuth/MFA bootstrap
- retain the singleton `Recreate` deployment model

## Bootstrap completed
- Garmin session token persisted on the `garmin-grafana` PVC
- token PVC snapshot completed successfully with VolSync
- temporary bootstrap pod removed

## Validation
- app-template HelmRelease schema validation passed
- Kubernetes server-side dry-run passed
- `flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose` — 212 passed
