### PR TITLE
feat(observability): announce scheduled rack migration

### DIFF
--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -5,6 +5,12 @@ web:
 metrics: true
 debug: false
 
+announcements:
+  - message: >-
+      Scheduled maintenance: all services will be offline from Friday 4 September 2026 at 09:00 AEST for a server rack migration. Expect full downtime through the weekend, followed by degraded media streaming performance for several days while storage migrates. Full service is expected by [END DATE].
+    type: warning
+    timestamp: "2026-09-04T09:00:00+10:00"
+
 storage:
   type: sqlite
   path: ${GATUS_CONFIG_PATH}/sqlite.db


### PR DESCRIPTION
## Summary
- add one warning banner for the scheduled 4 September 2026 rack migration
- describe the full-weekend outage and subsequent degraded streaming phase
- retain the end-date placeholder pending confirmation

## Validation
- parsed `resources/config.yaml` with Ruby Psych
- rendered the Gatus Kustomization with `kubectl kustomize`
- verified the rendered ConfigMap contains exactly the intended announcement
