### PR TITLE
fix(media): publish maintenance on Plexovic status

### DIFF
--- a/kubernetes/apps/media/plexovic-gatus/app/config/config.yaml
+++ b/kubernetes/apps/media/plexovic-gatus/app/config/config.yaml
@@ -7,6 +7,11 @@ storage:
   caching: true
 metrics: true
 debug: false
+announcements:
+  - message: >-
+      Scheduled maintenance: all services will be offline from Friday 4 September 2026 at 09:00 AEST for a server rack migration. Expect full downtime through the weekend, followed by degraded media streaming performance for several days while storage migrates. Full service is expected by [END DATE].
+    type: warning
+    timestamp: "2026-09-04T09:00:00+10:00"
 ui:
   title: Status | Plexovic
   header: Plexovic Status

--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -5,12 +5,6 @@ web:
 metrics: true
 debug: false
 
-announcements:
-  - message: >-
-      Scheduled maintenance: all services will be offline from Friday 4 September 2026 at 09:00 AEST for a server rack migration. Expect full downtime through the weekend, followed by degraded media streaming performance for several days while storage migrates. Full service is expected by [END DATE].
-    type: warning
-    timestamp: "2026-09-04T09:00:00+10:00"
-
 storage:
   type: sqlite
   path: ${GATUS_CONFIG_PATH}/sqlite.db


### PR DESCRIPTION
## Summary
- move the rack-migration announcement from the internal route-health dashboard to the public Plexovic status page
- preserve exactly one announcement and leave all endpoint and alerting configuration unchanged

## Validation
- parsed both Gatus YAML files successfully
- rendered both affected Kustomizations
- verified the rendered Plexovic ConfigMap contains the intended announcement
