### PR TITLE
fix(default): pin Tika to compatible release

### DIFF
--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
           tika:
             image:
               repository: mirror.gcr.io/apache/tika
-              tag: latest-full@sha256:d8e6ed96260ad89307a93195a1b856102987a818ac648502f8efbaf313d32470
+              tag: 3.3.1.0-full@sha256:d8e6ed96260ad89307a93195a1b856102987a818ac648502f8efbaf313d32470
           app:
             image:
               repository: ghcr.io/paperless-ngx/paperless-ngx


### PR DESCRIPTION
## Summary

- replace mutable `latest-full` with the immutable `3.3.1.0-full` Tika tag
- retain the existing digest, so the container image content is unchanged
- make future Tika major updates visible to Renovate instead of hiding them as digest refreshes

## Context

Renovate PR #3238 changes the digest behind `latest-full` from Tika 3.3.1 to 4.0.0. Paperless 3.0.5 currently uses `tika-client` 0.11 endpoints removed by Tika 4, so that update is not compatible yet.

The future Tika 4 migration is tracked in #3244.

The image reference change can cause a normal Paperless pod rollout, but both references resolve to the same image digest.

## Validation

- `mise x uv@0.12.3 -- uvx check-jsonschema --schemafile https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml`
- `skopeo inspect` confirms `3.3.1.0-full` resolves to `sha256:d8e6ed96260ad89307a93195a1b856102987a818ac648502f8efbaf313d32470` with `TIKA_VERSION=3.3.1`
