### PR TITLE
fix(storage): prevent Garage backup timeouts

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
@@ -21,3 +21,9 @@ spec:
       maxParallel: 8
     data:
       compression: bzip2
+      jobs: 1
+      # Bound Garage's per-object metadata growth and tolerate NFS commit latency.
+      additionalCommandArgs:
+        - --max-archive-size=10GB
+        - --min-chunk-size=100MB
+        - --read-timeout=300

--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -5,7 +5,7 @@ kind: ScheduledBackup
 metadata:
   name: postgres
 spec:
-  schedule: "@daily"
+  schedule: "0 0 2 * * *"
   immediate: true
   backupOwnerReference: self
   cluster:

--- a/kubernetes/apps/media/immich/database/objectstore.yaml
+++ b/kubernetes/apps/media/immich/database/objectstore.yaml
@@ -21,3 +21,9 @@ spec:
       maxParallel: 8
     data:
       compression: bzip2
+      jobs: 1
+      # Bound Garage's per-object metadata growth and tolerate NFS commit latency.
+      additionalCommandArgs:
+        - --max-archive-size=10GB
+        - --min-chunk-size=100MB
+        - --read-timeout=300

--- a/kubernetes/apps/media/immich/database/scheduledbackup.yaml
+++ b/kubernetes/apps/media/immich/database/scheduledbackup.yaml
@@ -5,7 +5,7 @@ kind: ScheduledBackup
 metadata:
   name: immich-postgres
 spec:
-  schedule: "@daily"
+  schedule: "0 0 1 * * *"
   immediate: true
   backupOwnerReference: self
   cluster:

--- a/kubernetes/apps/media/tracearr/database/objectstore.yaml
+++ b/kubernetes/apps/media/tracearr/database/objectstore.yaml
@@ -21,3 +21,9 @@ spec:
       maxParallel: 8
     data:
       compression: bzip2
+      jobs: 1
+      # Bound Garage's per-object metadata growth and tolerate NFS commit latency.
+      additionalCommandArgs:
+        - --max-archive-size=10GB
+        - --min-chunk-size=100MB
+        - --read-timeout=300

--- a/kubernetes/apps/media/tracearr/database/scheduledbackup.yaml
+++ b/kubernetes/apps/media/tracearr/database/scheduledbackup.yaml
@@ -5,7 +5,7 @@ kind: ScheduledBackup
 metadata:
   name: tracearr-postgres
 spec:
-  schedule: "@daily"
+  schedule: "0 0 0 * * *"
   immediate: true
   backupOwnerReference: self
   cluster:

--- a/kubernetes/apps/storage/garage/app/config/configuration.toml
+++ b/kubernetes/apps/storage/garage/app/config/configuration.toml
@@ -4,6 +4,7 @@ db_engine = "lmdb"
 metadata_auto_snapshot_interval = "6h"
 
 replication_factor = 1
+block_size = "10M"
 compression_level = 2
 
 rpc_bind_addr = "[::]:3901"


### PR DESCRIPTION
## Summary

- increase Garage's block size from 1 MiB to 10 MiB for newly uploaded large objects
- serialize Barman base-backup uploads and use 10 GB archives with 100 MB multipart chunks
- raise the Barman S3 read timeout from 60 seconds to 300 seconds
- stagger Tracearr, Immich, and shared PostgreSQL daily backups by one hour

## Why

Garage documents O(n²) metadata work as block references accumulate in large objects. The failed backups ran concurrently against one NFS-backed Garage pod, and Envoy recorded the Barman clients disconnecting at the exact 60-second read timeout while requests were still upstream. This reduces block metadata amplification and load, then provides a bounded latency allowance.

## Validation

- TOML parsed with Python `tomllib`
- all three ObjectStore manifests passed `check-jsonschema`
- all three ScheduledBackup manifests passed `check-jsonschema`
- Kustomize builds passed for Garage, shared CNPG, Immich database, and Tracearr database
