### PR TITLE
feat(teslamate): enable Home Assistant MQTT discovery

### DIFF
--- a/kubernetes/apps/automation/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/teslamate/app/helmrelease.yaml
@@ -42,6 +42,9 @@ spec:
             env:
               TZ: "${TZ}"
               DISABLE_MQTT: "false"
+              MQTT_HOME_ASSISTANT_DISCOVERY: "true"
+              MQTT_HOME_ASSISTANT_DISCOVERY_PREFIX: homeassistant
+              MQTT_HOME_ASSISTANT_DISCOVERY_URL: "https://teslamate.${SECRET_DOMAIN}"
               MQTT_HOST: mosquitto.automation.svc.cluster.local
             envFrom:
               - secretRef:


### PR DESCRIPTION
## Summary
- enable TeslaMate 4.2 Home Assistant MQTT device discovery
- pin the existing `homeassistant` discovery prefix
- publish the internal TeslaMate URL as device configuration metadata

## Rollout
- merge only after the 96 manual Home Assistant MQTT entities are removed
- map discovered entities by stable `teslamate_<car-id>_<component>` unique IDs
- validate Snow White (car 2) and Silver Surfer (car 35) before restoring garage and charging automations

## Validation
- `check-jsonschema` against the app-template HelmRelease schema
