### PR TITLE
fix(media): run Caddy without file capabilities

### DIFF
--- a/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
@@ -133,6 +133,11 @@ spec:
             image:
               repository: mirror.gcr.io/library/caddy
               tag: 2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                cp /usr/bin/caddy /tmp/caddy
+                exec /tmp/caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
             probes:
               liveness: &proxyProbe
                 enabled: true
@@ -208,3 +213,9 @@ spec:
               - path: /etc/caddy/Caddyfile
                 subPath: Caddyfile
                 readOnly: true
+      proxy-tmp:
+        type: emptyDir
+        advancedMounts:
+          dispatcharr:
+            proxy:
+              - path: /tmp


### PR DESCRIPTION
## Summary
- copy the Caddy binary into an emptyDir before launch
- preserve the non-root, read-only-root-filesystem, drop-all-capabilities security context

## Why
The official image binary has file capabilities and failed to exec with `operation not permitted` under the hardened container security context.

## Validation
- HelmRelease schema validation passed
- rendered StatefulSet includes the command and `/tmp` emptyDir mount
- the exact command ran successfully in a temporary pod with the same security context
