### PR TITLE
fix(storage): align VolSync mover file groups

### DIFF
--- a/kubernetes/apps/automation/garmin-grafana/ks.yaml
+++ b/kubernetes/apps/automation/garmin-grafana/ks.yaml
@@ -33,5 +33,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_UID: "1000"
+      VOLSYNC_GID: "1000"
       VOLSYNC_KOPIA_SCHEDULE: "50 * * * *"
       VOLSYNC_R2_SCHEDULE: "15 1 * * *"

--- a/kubernetes/apps/automation/meal-planner/ks.yaml
+++ b/kubernetes/apps/automation/meal-planner/ks.yaml
@@ -29,5 +29,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_UID: "65532"
+      VOLSYNC_GID: "65532"
       VOLSYNC_KOPIA_SCHEDULE: "58 * * * *"
       VOLSYNC_R2_SCHEDULE: "58 2 * * *"

--- a/kubernetes/apps/default/hister/ks.yaml
+++ b/kubernetes/apps/default/hister/ks.yaml
@@ -29,5 +29,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_UID: "65532"
+      VOLSYNC_GID: "65532"
       VOLSYNC_KOPIA_SCHEDULE: "23 * * * *"
       VOLSYNC_R2_SCHEDULE: "44 1 * * *"

--- a/kubernetes/apps/default/homebox/ks.yaml
+++ b/kubernetes/apps/default/homebox/ks.yaml
@@ -29,5 +29,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "65532"
+      VOLSYNC_GID: "65532"
       VOLSYNC_KOPIA_SCHEDULE: "44 * * * *"
       VOLSYNC_R2_SCHEDULE: "44 1 * * *"

--- a/kubernetes/apps/default/marginalia/ks.yaml
+++ b/kubernetes/apps/default/marginalia/ks.yaml
@@ -32,5 +32,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 2Gi
+      VOLSYNC_UID: "65532"
+      VOLSYNC_GID: "65532"
       VOLSYNC_KOPIA_SCHEDULE: "42 * * * *"
       VOLSYNC_R2_SCHEDULE: "10 2 * * *"

--- a/kubernetes/apps/media/profilarr/ks.yaml
+++ b/kubernetes/apps/media/profilarr/ks.yaml
@@ -29,5 +29,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "1000"
+      VOLSYNC_GID: "1000"
       VOLSYNC_KOPIA_SCHEDULE: "52 * * * *"
       VOLSYNC_R2_SCHEDULE: "18 5 * * *"

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -33,5 +33,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_UID: "1000"
+      VOLSYNC_GID: "1000"
       VOLSYNC_KOPIA_SCHEDULE: "45 * * * *"
       VOLSYNC_R2_SCHEDULE: "50 3 * * *"

--- a/kubernetes/components/volsync/r2.yaml
+++ b/kubernetes/components/volsync/r2.yaml
@@ -43,9 +43,9 @@ spec:
     storageClassName: "${VOLSYNC_STORAGECLASS:-ceph-block}"
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     moverSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
+      runAsUser: ${VOLSYNC_UID:-568}
+      runAsGroup: 568 # Injected Kopia NFS repository group
+      fsGroup: ${VOLSYNC_GID:-568}
       fsGroupChangePolicy: OnRootMismatch
     retain:
       daily: 7

--- a/kubernetes/components/volsync/replicationdestination.yaml
+++ b/kubernetes/components/volsync/replicationdestination.yaml
@@ -18,9 +18,9 @@ spec:
     copyMethod: Snapshot
     enableFileDeletion: true
     moverSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
+      runAsUser: ${VOLSYNC_UID:-568}
+      runAsGroup: 568 # Kopia NFS repository group
+      fsGroup: ${VOLSYNC_GID:-568}
       fsGroupChangePolicy: OnRootMismatch
     repository: ${APP}-volsync-secret
     sourceIdentity:

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -14,9 +14,9 @@ spec:
     compression: zstd-fastest
     copyMethod: Snapshot
     moverSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
+      runAsUser: ${VOLSYNC_UID:-568}
+      runAsGroup: 568 # Kopia NFS repository group
+      fsGroup: ${VOLSYNC_GID:-568}
       fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: ${APP}-volsync-secret


### PR DESCRIPTION
## Summary
- parameterize VolSync mover UID and fsGroup for Kopia, restore, and R2 movers
- align mover ownership with eight applications using non-default file groups
- retain primary GID 568 for the injected shared Kopia NFS repository

## Why
Snapshot clones retained each application's file group while VolSync forced GID 568. `OnRootMismatch` therefore recursively changed ownership across every inode before backups, saturating nodes with metadata I/O.

## Validation
- `check-jsonschema` passed for rendered VolSync and Flux resources
- rendered mover identities verified for all affected apps and default Plex behavior
- `flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose` — 214 passed
