### PR TITLE
fix(storage): unlock stale R2 repositories

### DIFF
--- a/kubernetes/apps/automation/changedetection/ks.yaml
+++ b/kubernetes/apps/automation/changedetection/ks.yaml
@@ -12,6 +12,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/volsync-r2-unlock
   path: ./kubernetes/apps/automation/changedetection/app
   prune: true
   sourceRef:
@@ -31,3 +32,4 @@ spec:
       VOLSYNC_CAPACITY: 1Gi
       VOLSYNC_KOPIA_SCHEDULE: "56 * * * *"
       VOLSYNC_R2_SCHEDULE: "0 0 * * *"
+      VOLSYNC_R2_UNLOCK: "2026-09-01-stale-lock-recovery"

--- a/kubernetes/apps/automation/esphome/ks.yaml
+++ b/kubernetes/apps/automation/esphome/ks.yaml
@@ -12,6 +12,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/volsync-r2-unlock
   dependsOn:
     - name: multus-config
       namespace: network
@@ -33,3 +34,4 @@ spec:
       VOLSYNC_CAPACITY: 1Gi
       VOLSYNC_KOPIA_SCHEDULE: "54 * * * *"
       VOLSYNC_R2_SCHEDULE: "5 2 * * *"
+      VOLSYNC_R2_UNLOCK: "2026-09-01-stale-lock-recovery"

--- a/kubernetes/apps/automation/frigate/ks.yaml
+++ b/kubernetes/apps/automation/frigate/ks.yaml
@@ -12,6 +12,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/volsync-r2-unlock
   path: ./kubernetes/apps/automation/frigate/app
   prune: true
   sourceRef:
@@ -35,3 +36,4 @@ spec:
       VOLSYNC_CAPACITY: 5Gi
       VOLSYNC_KOPIA_SCHEDULE: "30 * * * *"
       VOLSYNC_R2_SCHEDULE: "50 1 * * *"
+      VOLSYNC_R2_UNLOCK: "2026-09-01-stale-lock-recovery"

--- a/kubernetes/apps/automation/home-assistant/ks.yaml
+++ b/kubernetes/apps/automation/home-assistant/ks.yaml
@@ -12,6 +12,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/volsync-r2-unlock
   dependsOn:
     - name: external-secrets-stores
       namespace: external-secrets
@@ -37,3 +38,4 @@ spec:
       VOLSYNC_CAPACITY: 10Gi
       VOLSYNC_KOPIA_SCHEDULE: "12 * * * *"
       VOLSYNC_R2_SCHEDULE: "30 0 * * *"
+      VOLSYNC_R2_UNLOCK: "2026-09-01-stale-lock-recovery"

--- a/kubernetes/apps/default/homebox/ks.yaml
+++ b/kubernetes/apps/default/homebox/ks.yaml
@@ -12,6 +12,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/volsync-r2-unlock
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
@@ -33,3 +34,4 @@ spec:
       VOLSYNC_GID: "65532"
       VOLSYNC_KOPIA_SCHEDULE: "44 * * * *"
       VOLSYNC_R2_SCHEDULE: "44 1 * * *"
+      VOLSYNC_R2_UNLOCK: "2026-09-01-stale-lock-recovery"

--- a/kubernetes/apps/observability/influxdb/ks.yaml
+++ b/kubernetes/apps/observability/influxdb/ks.yaml
@@ -12,6 +12,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/volsync-r2-unlock
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
@@ -31,3 +32,4 @@ spec:
       VOLSYNC_CAPACITY: 10Gi
       VOLSYNC_KOPIA_SCHEDULE: "10 * * * *"
       VOLSYNC_R2_SCHEDULE: "30 1 * * *"
+      VOLSYNC_R2_UNLOCK: "2026-09-01-stale-lock-recovery"

--- a/kubernetes/components/volsync-r2-unlock/kustomization.yaml
+++ b/kubernetes/components/volsync-r2-unlock/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - patch: |
+      - op: add
+        path: /spec/restic/unlock
+        value: "${VOLSYNC_R2_UNLOCK}"
+    target:
+      group: volsync.backube
+      version: v1alpha1
+      kind: ReplicationSource
+      name: .*-r2


### PR DESCRIPTION
## Summary
- add a targeted reusable VolSync R2 unlock component
- trigger one-shot stale-lock recovery for Changedetection, ESPHome, Frigate, Home Assistant, Homebox, and InfluxDB
- leave all unaffected R2 repositories unchanged

## Why
Transient R2 latency triggered VolSync's hard-coded 60-second `restic cat config` timeout and orphaned repository locks. Job retries repeatedly rescanned Ceph snapshot clones and caused NodeSystemSaturation.

## Validation
- rendered all six Flux Kustomizations locally and confirmed the expected `spec.restic.unlock` token
- validated all six Flux Kustomizations and the new component with `check-jsonschema`
- full flux-local container validation unavailable because the local Docker daemon is not running
