### PR TITLE
fix(storage): prevent Restic config-probe locks

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/helmrelease.yaml
@@ -20,8 +20,8 @@ spec:
   values:
     fullnameOverride: volsync
     image: &image
-      repository: ghcr.io/perfectra1n/volsync
-      tag: v0.17.11@sha256:79674d3c48685e21cadaac8e0afd14268130a0a51a10c41a9dd65096c1434a0f
+      repository: ghcr.io/adampetrovic/volsync
+      tag: v0.17.11-nolock.2@sha256:775a2aacfaa165454ce12b544961a0434291ba311a194b3cd967405f692aef5e
     kopia: *image
     rclone: *image
     restic: *image


### PR DESCRIPTION
## Summary
- deploy a custom VolSync v0.17.11 mover image that runs the Restic config probe with `--no-lock`
- pin the new multi-architecture image by tag and OCI index digest
- retain normal Restic locking for backup, forget, and prune

## Why
Transient R2 latency can exceed VolSync's 60-second `restic cat config` timeout. The terminated probe may orphan a repository lock, causing retries and storage saturation.

## Validation
- image build succeeded for linux/amd64 and linux/arm64
- image is publicly pullable and digest matches `sha256:775a2aacfaa165454ce12b544961a0434291ba311a194b3cd967405f692aef5e`
- HelmRelease schema validation passed
- Flux local render contains the expected repository, tag, and digest
