### PR TITLE
feat(storage): add safe R2 recovery tasks

### DIFF
--- a/.taskfiles/VolSync/Taskfile.yaml
+++ b/.taskfiles/VolSync/Taskfile.yaml
@@ -10,6 +10,7 @@ version: "3"
 
 x-env: &env
   app: "{{.app}}"
+  backupTimeout: "{{.backupTimeout}}"
   claim: "{{.claim}}"
   controller: "{{.controller}}"
   job: "{{.job}}"
@@ -19,166 +20,263 @@ x-env: &env
   restoreAsOf: "{{.restoreAsOf}}"
   timeout: "{{.timeout}}"
   puid: "{{.puid}}"
+  verify: "{{.verify}}"
 
 vars:
   VOLSYNC_SCRIPTS_DIR: "{{.ROOT_DIR}}/.taskfiles/VolSync/scripts"
   VOLSYNC_TEMPLATES_DIR: "{{.ROOT_DIR}}/.taskfiles/VolSync/templates"
 
 tasks:
-  debug:
-    desc: Debug restic
+  debug-r2:
+    desc: Create an interactive Restic debug Pod for an R2 repository
     summary: |
-      Args:
-        ns: Namespace the PVC is in (default: default)
-        app: Application to check (required)
-    cmds:
-      - envsubst < <(cat {{.VOLSYNC_TEMPLATES_DIR}}/debug.tmpl.yaml) | kubectl apply -f -
-    env: *env
-    requires:
-      vars: ["app"]
-    vars:
-      ns: '{{.ns | default "default"}}'
-      job: volsync-debug-{{.app}}
-    preconditions:
-      - test -f {{.VOLSYNC_TEMPLATES_DIR}}/debug.tmpl.yaml
-    silent: true
-
-  check:
-    desc: Check volsync for repo
-    summary: |
-      Args:
-        ns: Namespace the PVC is in (default: default)
-        app: Application to check (required)
-    cmds:
-      - envsubst < <(cat {{.VOLSYNC_TEMPLATES_DIR}}/check.tmpl.yaml) | kubectl apply -f -
-      - bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh {{.job}} {{.ns}}
-      - kubectl -n {{.ns}} wait job/{{.job}} --for condition=complete --timeout=1m
-      - kubectl -n {{.ns}} logs job/{{.job}} --container main
-      - kubectl -n {{.ns}} delete job {{.job}}
-    env: *env
-    requires:
-      vars: ["app"]
-    vars:
-      ns: '{{.ns | default "default"}}'
-      job: volsync-check-{{.app}}
-    preconditions:
-      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh
-      - test -f {{.VOLSYNC_TEMPLATES_DIR}}/check.tmpl.yaml
-    silent: true
-
-  list:
-    desc: List snapshots for an application
-    summary: |
-      Args:
-        ns: Namespace the PVC is in (default: default)
-        app: Application to list snapshots for (required)
-    cmds:
-      - envsubst '$app $ns $job' < {{.VOLSYNC_TEMPLATES_DIR}}/list.tmpl.yaml | kubectl apply -f -
-      - bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh {{.job}} {{.ns}}
-      - kubectl -n {{.ns}} wait job/{{.job}} --for condition=complete --timeout=5m
-      - kubectl -n {{.ns}} logs job/{{.job}} --container main
-      - kubectl -n {{.ns}} delete job {{.job}}
-    env: *env
-    requires:
-      vars: ["app"]
-    vars:
-      ns: '{{.ns | default "default"}}'
-      job: volsync-list-{{.app}}
-    preconditions:
-      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh
-      - test -f {{.VOLSYNC_TEMPLATES_DIR}}/list.tmpl.yaml
-    silent: true
-
-  unlock:
-    desc: Unlock a Restic repository for an application
-    summary: |
-      Args:
-        ns: Namespace the PVC is in (default: default)
-        app: Application to unlock (required)
-    cmds:
-      - envsubst < <(cat {{.VOLSYNC_TEMPLATES_DIR}}/unlock.tmpl.yaml) | kubectl apply -f -
-      - bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh {{.job}} {{.ns}}
-      - kubectl -n {{.ns}} wait job/{{.job}} --for condition=complete --timeout=1m
-      - kubectl -n {{.ns}} logs job/{{.job}} --container garage
-      - kubectl -n {{.ns}} logs job/{{.job}} --container r2
-      - kubectl -n {{.ns}} delete job {{.job}}
-    env: *env
-    requires:
-      vars: ["app"]
-    vars:
-      ns: '{{.ns | default "default"}}'
-      job: volsync-unlock-{{.app}}
-    preconditions:
-      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh
-      - test -f {{.VOLSYNC_TEMPLATES_DIR}}/unlock.tmpl.yaml
-    silent: true
-
-  backup:
-    desc: Trigger an ad-hoc VolSync backup for an application
-    summary: |
-      Triggers an immediate VolSync backup for an application by patching the
-      ReplicationSource manual trigger. Runs each selected backend sequentially
-      and waits for completion.
+      Creates a non-root debug Pod using the application's R2 Restic Secret.
+      Delete it when finished with:
+        kubectl --context admin@home-kubernetes -n <namespace> delete pod volsync-r2-debug-<app>
 
       Args:
         app: Application name (required)
-        ns: Namespace the PVC is in (default: default)
-        type: Backend to trigger - kopia, r2, or all (default: kopia)
+        ns: Namespace (default: default)
     cmds:
+      - bash {{.VOLSYNC_SCRIPTS_DIR}}/preflight-r2-operation.sh {{.app}} {{.ns}} inspect
+      - envsubst '$app $ns $job' < {{.VOLSYNC_TEMPLATES_DIR}}/debug.tmpl.yaml | kubectl --context admin@home-kubernetes create -f -
+      - echo "Debug Pod {{.ns}}/{{.job}} created; use container r2 and delete it when finished."
+    env: *env
+    requires:
+      vars: ["app"]
+    vars:
+      ns: '{{.ns | default "default"}}'
+      job: volsync-r2-debug-{{.app}}
+    preconditions:
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/preflight-r2-operation.sh
+      - test -f {{.VOLSYNC_TEMPLATES_DIR}}/debug.tmpl.yaml
+    silent: true
+
+  debug:
+    desc: Deprecated alias for debug-r2
+    cmds:
+      - echo "DEPRECATED - use 'task volsync:debug-r2 app={{.app}} ns={{.ns}}'."
+      - task: debug-r2
+        vars:
+          app: "{{.app}}"
+          ns: "{{.ns}}"
+    requires:
+      vars: ["app"]
+    vars:
+      ns: '{{.ns | default "default"}}'
+    silent: true
+
+  check-r2:
+    desc: Check an R2 Restic repository
+    summary: |
+      Runs a metadata-only Restic check against Cloudflare R2. This can be slow
+      and may incur API/download costs; it does not use --read-data.
+
+      Args:
+        app: Application name (required)
+        ns: Namespace (default: default)
+        timeout: Maximum wait in seconds (default: 3600)
+    cmds:
+      - bash {{.VOLSYNC_SCRIPTS_DIR}}/preflight-r2-operation.sh {{.app}} {{.ns}} exclusive
+      - envsubst '$app $ns $job $timeout' < {{.VOLSYNC_TEMPLATES_DIR}}/check.tmpl.yaml | kubectl --context admin@home-kubernetes create -f -
+      - bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-operation-job.sh {{.job}} {{.ns}} {{.timeout}}
+      - kubectl --context admin@home-kubernetes -n {{.ns}} delete job {{.job}}
+    env: *env
+    requires:
+      vars: ["app"]
+    vars:
+      ns: '{{.ns | default "default"}}'
+      timeout: '{{.timeout | default "3600"}}'
+      job: volsync-r2-check-{{.app}}
+    preconditions:
+      - sh: '[[ "{{.timeout}}" =~ ^[1-9][0-9]*$ ]]'
+        msg: "timeout must be a positive integer"
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/preflight-r2-operation.sh
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-operation-job.sh
+      - test -f {{.VOLSYNC_TEMPLATES_DIR}}/check.tmpl.yaml
+    silent: true
+
+  check:
+    desc: Deprecated alias for check-r2
+    cmds:
+      - echo "DEPRECATED - use 'task volsync:check-r2 app={{.app}} ns={{.ns}}'."
+      - task: check-r2
+        vars:
+          app: "{{.app}}"
+          ns: "{{.ns}}"
+          timeout: "{{.timeout}}"
+    requires:
+      vars: ["app"]
+    vars:
+      ns: '{{.ns | default "default"}}'
+      timeout: '{{.timeout | default "3600"}}'
+    silent: true
+
+  list:
+    desc: List Kopia snapshots for an application
+    summary: |
+      Lists snapshots from the primary Kopia/NFS repository.
+
+      Args:
+        app: Application name (required)
+        ns: Namespace (default: default)
+        timeout: Maximum wait in seconds (default: 300)
+    cmds:
+      - envsubst '$app $ns $job $timeout' < {{.VOLSYNC_TEMPLATES_DIR}}/list.tmpl.yaml | kubectl --context admin@home-kubernetes create -f -
+      - bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-operation-job.sh {{.job}} {{.ns}} {{.timeout}}
+      - kubectl --context admin@home-kubernetes -n {{.ns}} delete job {{.job}}
+    env: *env
+    requires:
+      vars: ["app"]
+    vars:
+      ns: '{{.ns | default "default"}}'
+      timeout: '{{.timeout | default "300"}}'
+      job: volsync-list-{{.app}}
+    preconditions:
+      - sh: '[[ "{{.timeout}}" =~ ^[1-9][0-9]*$ ]]'
+        msg: "timeout must be a positive integer"
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-operation-job.sh
+      - test -f {{.VOLSYNC_TEMPLATES_DIR}}/list.tmpl.yaml
+    silent: true
+
+  locks-r2:
+    desc: Inspect Restic locks in an R2 repository
+    summary: |
+      Read-only lock inspection. It uses --no-lock and never changes the repository.
+
+      Args:
+        app: Application name (required)
+        ns: Namespace (default: default)
+        timeout: Maximum wait in seconds (default: 600)
+    cmds:
+      - bash {{.VOLSYNC_SCRIPTS_DIR}}/preflight-r2-operation.sh {{.app}} {{.ns}} inspect
+      - envsubst '$app $ns $job $timeout' < {{.VOLSYNC_TEMPLATES_DIR}}/locks-r2.tmpl.yaml | kubectl --context admin@home-kubernetes create -f -
+      - bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-operation-job.sh {{.job}} {{.ns}} {{.timeout}}
+      - kubectl --context admin@home-kubernetes -n {{.ns}} delete job {{.job}}
+    env: *env
+    requires:
+      vars: ["app"]
+    vars:
+      ns: '{{.ns | default "default"}}'
+      timeout: '{{.timeout | default "600"}}'
+      job: volsync-r2-locks-{{.app}}
+    preconditions:
+      - sh: '[[ "{{.timeout}}" =~ ^[1-9][0-9]*$ ]]'
+        msg: "timeout must be a positive integer"
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/preflight-r2-operation.sh
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-operation-job.sh
+      - test -f {{.VOLSYNC_TEMPLATES_DIR}}/locks-r2.tmpl.yaml
+    silent: true
+
+  unlock-r2:
+    desc: Safely remove stale Restic locks from an R2 repository
+    summary: |
+      Runs plain 'restic unlock' after confirming no active or ambiguous owners.
+      There is intentionally no force or --remove-all mode.
+
+      Args:
+        app: Application name (required)
+        ns: Namespace (default: default)
+        timeout: Maximum unlock wait in seconds (default: 600)
+        verify: Trigger and verify one R2 backup afterwards (default: false)
+        backupTimeout: Maximum backup wait in seconds (default: 7200)
+    cmds:
+      - bash {{.VOLSYNC_SCRIPTS_DIR}}/preflight-r2-operation.sh {{.app}} {{.ns}} exclusive
+      - envsubst '$app $ns $job $timeout' < {{.VOLSYNC_TEMPLATES_DIR}}/unlock.tmpl.yaml | kubectl --context admin@home-kubernetes create -f -
+      - bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-operation-job.sh {{.job}} {{.ns}} {{.timeout}}
+      - kubectl --context admin@home-kubernetes -n {{.ns}} delete job {{.job}}
       - cmd: |
-          if [[ "{{.type}}" == "kopia" || "{{.type}}" == "all" ]]; then
-            echo "Triggering Kopia backup for {{.app}} in {{.ns}}..."
-            kubectl -n {{.ns}} patch replicationsources {{.app}} --type merge \
-              -p '{"spec":{"trigger":{"manual":"{{.now}}"}}}'
-            bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh volsync-src-{{.app}} {{.ns}}
-            kubectl -n {{.ns}} wait job/volsync-src-{{.app}} --for condition=complete --timeout=120m
-            echo "✓ Kopia backup completed for {{.app}}"
+          if [[ "{{.verify}}" == "true" ]]; then
+              task volsync:backup app={{.app}} ns={{.ns}} type=r2 timeout={{.backupTimeout}}
           fi
-      - cmd: |
-          if [[ "{{.type}}" == "r2" || "{{.type}}" == "all" ]]; then
-            echo "Triggering R2 backup for {{.app}} in {{.ns}}..."
-            kubectl -n {{.ns}} patch replicationsources {{.app}}-r2 --type merge \
-              -p '{"spec":{"trigger":{"manual":"{{.now}}"}}}'
-            bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh volsync-src-{{.app}}-r2 {{.ns}}
-            kubectl -n {{.ns}} wait job/volsync-src-{{.app}}-r2 --for condition=complete --timeout=120m
-            echo "✓ R2 backup completed for {{.app}}"
-          fi
+    env: *env
+    requires:
+      vars: ["app"]
+    vars:
+      ns: '{{.ns | default "default"}}'
+      timeout: '{{.timeout | default "600"}}'
+      verify: '{{.verify | default "false"}}'
+      backupTimeout: '{{.backupTimeout | default "7200"}}'
+      job: volsync-r2-unlock-{{.app}}
+    preconditions:
+      - sh: '[[ "{{.verify}}" == "true" || "{{.verify}}" == "false" ]]'
+        msg: "verify must be true or false"
+      - sh: '[[ "{{.timeout}}" =~ ^[1-9][0-9]*$ ]]'
+        msg: "timeout must be a positive integer"
+      - sh: '[[ "{{.backupTimeout}}" =~ ^[1-9][0-9]*$ ]]'
+        msg: "backupTimeout must be a positive integer"
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/preflight-r2-operation.sh
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-operation-job.sh
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-replicationsource.sh
+      - test -f {{.VOLSYNC_TEMPLATES_DIR}}/unlock.tmpl.yaml
+    silent: true
+
+  unlock:
+    desc: Deprecated alias for unlock-r2
+    cmds:
+      - echo "DEPRECATED - use 'task volsync:unlock-r2 app={{.app}} ns={{.ns}}'."
+      - task: unlock-r2
+        vars:
+          app: "{{.app}}"
+          ns: "{{.ns}}"
+          timeout: "{{.timeout}}"
+          verify: "{{.verify}}"
+          backupTimeout: "{{.backupTimeout}}"
+    requires:
+      vars: ["app"]
+    vars:
+      ns: '{{.ns | default "default"}}'
+      timeout: '{{.timeout | default "600"}}'
+      verify: '{{.verify | default "false"}}'
+      backupTimeout: '{{.backupTimeout | default "7200"}}'
+    silent: true
+
+  backup:
+    desc: Trigger and verify an ad-hoc VolSync backup
+    summary: |
+      Triggers one or both ReplicationSources sequentially and waits for the
+      exact manual token to complete.
+
+      Args:
+        app: Application name (required)
+        ns: Namespace (default: default)
+        type: Backend - kopia, r2, or all (default: kopia)
+        timeout: Maximum wait per backup in seconds (default: 7200)
+    cmds:
+      - bash {{.VOLSYNC_SCRIPTS_DIR}}/trigger-backup.sh {{.app}} {{.ns}} {{.type}} {{.timeout}}
     env: *env
     requires:
       vars: ["app"]
     vars:
       ns: '{{.ns | default "default"}}'
       type: '{{.type | default "kopia"}}'
-      now: '{{now | date "150405"}}'
+      timeout: '{{.timeout | default "7200"}}'
     preconditions:
-      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh
+      - sh: '[[ "{{.type}}" =~ ^(kopia|r2|all)$ ]]'
+        msg: "type must be kopia, r2, or all"
+      - sh: '[[ "{{.timeout}}" =~ ^[1-9][0-9]*$ ]]'
+        msg: "timeout must be a positive integer"
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/preflight-r2-operation.sh
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/trigger-backup.sh
+      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-replicationsource.sh
     silent: true
 
-  # To run backup jobs in parallel for all replicationsources:
-  #   - kubectl get replicationsources --all-namespaces --no-headers | awk '{print $2, $1}' | xargs --max-procs=4 -l bash -c 'task volsync:snapshot app=$0 ns=$1'
   snapshot:
-    desc: Snapshot a PVC for an application
-    summary: |
-      Args:
-        ns: Namespace the PVC is in (default: default)
-        app: Application to snapshot (required)
+    desc: Deprecated alias for a Kopia backup
     cmds:
-      - kubectl -n {{.ns}} patch replicationsources {{.app}} --type merge -p '{"spec":{"trigger":{"manual":"{{.now}}"}}}'
-      - bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh {{.job}} {{.ns}}
-      - kubectl -n {{.ns}} wait job/{{.job}} --for condition=complete --timeout=120m
-    env: *env
+      - echo "DEPRECATED - use 'task volsync:backup app={{.app}} ns={{.ns}} type=kopia'."
+      - task: backup
+        vars:
+          app: "{{.app}}"
+          ns: "{{.ns}}"
+          type: kopia
+          timeout: "{{.timeout}}"
     requires:
       vars: ["app"]
     vars:
-      now: '{{now | date "150405"}}'
       ns: '{{.ns | default "default"}}'
-      job: volsync-src-{{.app}}
-      controller:
-        sh: true && {{.VOLSYNC_SCRIPTS_DIR}}/which-controller.sh {{.app}} {{.ns}}
-    preconditions:
-      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/which-controller.sh
-      - test -f {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-job.sh
-      - kubectl -n {{.ns}} get replicationsources {{.app}}
+      timeout: '{{.timeout | default "7200"}}'
+    silent: true
 
   # To run restore jobs in parallel for all replicationdestinations:
   #    - kubectl get replicationsources --all-namespaces --no-headers | awk '{print $2, $1}' | xargs --max-procs=4 -l bash -c 'task volsync:restore app=$0 ns=$1'

--- a/.taskfiles/VolSync/scripts/preflight-r2-operation.sh
+++ b/.taskfiles/VolSync/scripts/preflight-r2-operation.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly CONTEXT="admin@home-kubernetes"
+
+APP="${1:-}"
+NAMESPACE="${2:-default}"
+MODE="${3:-exclusive}"
+SOURCE="${APP}-r2"
+SECRET="${APP}-volsync-r2-secret"
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+print_items() {
+    local item
+    while IFS= read -r item; do
+        echo "  - ${item}" >&2
+    done <<<"$1"
+}
+
+validate_name() {
+    local kind=$1
+    local value=$2
+
+    [[ ${#value} -le 63 ]] || fail "${kind} must be at most 63 characters"
+    [[ ${value} =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || \
+        fail "${kind} must be a lowercase DNS label: ${value}"
+}
+
+[[ -n ${APP} ]] || fail "Application name not specified"
+[[ ${MODE} == "inspect" || ${MODE} == "exclusive" ]] || \
+    fail "Mode must be inspect or exclusive"
+validate_name "Application" "${APP}"
+validate_name "Namespace" "${NAMESPACE}"
+for job_prefix in volsync-r2-locks- volsync-r2-unlock- volsync-r2-check- volsync-r2-debug-; do
+    (( ${#job_prefix} + ${#APP} <= 63 )) || \
+        fail "Application name is too long for Taskfile operation Job names: ${APP}"
+done
+
+kubectl config get-contexts -o name | grep -Fxq "${CONTEXT}" || \
+    fail "Kubernetes context ${CONTEXT} is not configured"
+kubectl --context "${CONTEXT}" version --request-timeout=10s >/dev/null || \
+    fail "Kubernetes API is not reachable through ${CONTEXT}"
+kubectl --context "${CONTEXT}" get namespace "${NAMESPACE}" >/dev/null || \
+    fail "Namespace ${NAMESPACE} does not exist"
+
+source_json=$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" \
+    get replicationsource "${SOURCE}" -o json) || \
+    fail "ReplicationSource ${NAMESPACE}/${SOURCE} does not exist"
+
+jq -e --arg secret "${SECRET}" \
+    '.spec.restic.repository == $secret and (.spec.restic | type == "object")' \
+    <<<"${source_json}" >/dev/null || \
+    fail "${NAMESPACE}/${SOURCE} is not a Restic source using ${SECRET}"
+
+secret_json=$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" \
+    get secret "${SECRET}" -o json) || \
+    fail "Secret ${NAMESPACE}/${SECRET} does not exist"
+
+jq -e '.data
+    | has("RESTIC_REPOSITORY")
+    and has("RESTIC_PASSWORD")
+    and has("AWS_ACCESS_KEY_ID")
+    and has("AWS_SECRET_ACCESS_KEY")' \
+    <<<"${secret_json}" >/dev/null || \
+    fail "${NAMESPACE}/${SECRET} is missing required Restic or R2 keys"
+
+echo "Target: ${NAMESPACE}/${SOURCE} via ${SECRET}"
+echo "Context: ${CONTEXT}"
+
+operation_jobs=$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" get jobs -o json | \
+    jq -r --arg app "${APP}" '.items[]
+        | select(.metadata.labels["home-ops.petrovic.io/volsync-app"] == $app)
+        | .metadata.name')
+if [[ -n ${operation_jobs} ]]; then
+    echo "Existing Taskfile operation Jobs:" >&2
+    print_items "${operation_jobs}"
+    fail "Inspect or delete the existing Job before retrying"
+fi
+
+if [[ ${MODE} == "inspect" ]]; then
+    echo "Preflight passed for read-only R2 lock inspection."
+    exit 0
+fi
+
+sync_status=$(jq -r '[.status.conditions[]?
+    | select(.type == "Synchronizing")
+    | .status] | last // "Missing"' <<<"${source_json}")
+[[ ${sync_status} == "False" ]] || \
+    fail "${NAMESPACE}/${SOURCE} Synchronizing status is ${sync_status}; wait for it to become False"
+
+active_jobs=$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" get jobs -o json | \
+    jq -r --arg source "${SOURCE}" '.items[]
+        | select((.status.active // 0) > 0)
+        | select(any(.metadata.ownerReferences[]?;
+            .kind == "ReplicationSource" and .name == $source))
+        | .metadata.name')
+if [[ -n ${active_jobs} ]]; then
+    echo "Active mover Jobs owned by ${SOURCE}:" >&2
+    print_items "${active_jobs}"
+    fail "An active mover may own a legitimate Restic lock"
+fi
+
+active_sources=$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" \
+    get replicationsources -o json | \
+    jq -r --arg source "${SOURCE}" --arg secret "${SECRET}" '.items[]
+        | select(.metadata.name != $source)
+        | select((.spec.restic.repository // "") == $secret)
+        | select(any(.status.conditions[]?;
+            .type == "Synchronizing" and .status == "True"))
+        | .metadata.name')
+active_destinations=$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" \
+    get replicationdestinations -o json | \
+    jq -r --arg secret "${SECRET}" '.items[]
+        | select((.spec.restic.repository // "") == $secret)
+        | select(any(.status.conditions[]?;
+            .type == "Synchronizing" and .status == "True"))
+        | .metadata.name')
+if [[ -n ${active_sources}${active_destinations} ]]; then
+    [[ -z ${active_sources} ]] || {
+        echo "Other active ReplicationSources using ${SECRET}:" >&2
+        print_items "${active_sources}"
+    }
+    [[ -z ${active_destinations} ]] || {
+        echo "Active ReplicationDestinations using ${SECRET}:" >&2
+        print_items "${active_destinations}"
+    }
+    fail "Another replication may own a legitimate Restic lock"
+fi
+
+active_pods=$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" get pods -o json | \
+    jq -r --arg secret "${SECRET}" '
+        def all_containers: ((.spec.initContainers // []) + (.spec.containers // []));
+        .items[]
+        | select(.status.phase == "Pending" or .status.phase == "Running")
+        | select(any(all_containers[]?;
+            any(.envFrom[]?; .secretRef.name == $secret)
+            or any(.env[]?; .valueFrom.secretKeyRef.name == $secret)))
+        | .metadata.name')
+if [[ -n ${active_pods} ]]; then
+    echo "Pending or Running Pods using ${SECRET}:" >&2
+    print_items "${active_pods}"
+    fail "An active Pod may own a legitimate Restic lock"
+fi
+
+echo "Preflight passed: no active or ambiguous R2 repository owners found."

--- a/.taskfiles/VolSync/scripts/trigger-backup.sh
+++ b/.taskfiles/VolSync/scripts/trigger-backup.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly CONTEXT="admin@home-kubernetes"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
+APP="${1:-}"
+NAMESPACE="${2:-default}"
+TYPE="${3:-kopia}"
+TIMEOUT="${4:-7200}"
+cleanup_source=""
+cleanup_token=""
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+cleanup_manual_trigger() {
+    [[ -n ${cleanup_source} && -n ${cleanup_token} ]] || return 0
+
+    local attempt current_manual
+    for attempt in 1 2 3 4 5; do
+        if kubectl --context "${CONTEXT}" -n "${NAMESPACE}" \
+            patch replicationsource "${cleanup_source}" --type json \
+            -p "[{\"op\":\"test\",\"path\":\"/spec/trigger/manual\",\"value\":\"${cleanup_token}\"},{\"op\":\"remove\",\"path\":\"/spec/trigger/manual\"}]" \
+            >/dev/null 2>&1; then
+            echo "Restored the scheduled trigger on ${cleanup_source}."
+            cleanup_source=""
+            cleanup_token=""
+            return 0
+        fi
+
+        if current_manual=$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" \
+            get replicationsource "${cleanup_source}" \
+            -o jsonpath='{.spec.trigger.manual}' 2>/dev/null); then
+            if [[ ${current_manual} != "${cleanup_token}" ]]; then
+                echo "Manual trigger on ${cleanup_source} no longer belongs to this task; leaving it unchanged."
+                cleanup_source=""
+                cleanup_token=""
+                return 0
+            fi
+        fi
+
+        (( attempt == 5 )) || sleep 2
+    done
+
+    echo "ERROR: could not remove manual trigger ${cleanup_token} from ${cleanup_source}." >&2
+    echo "Scheduled backups may remain paused; rerun cleanup after restoring API access:" >&2
+    echo "  kubectl --context ${CONTEXT} -n ${NAMESPACE} patch replicationsource ${cleanup_source} --type json -p '[{\"op\":\"test\",\"path\":\"/spec/trigger/manual\",\"value\":\"${cleanup_token}\"},{\"op\":\"remove\",\"path\":\"/spec/trigger/manual\"}]'" >&2
+    return 1
+}
+
+on_exit() {
+    local rc=$?
+    trap - EXIT
+    cleanup_manual_trigger || rc=1
+    exit "${rc}"
+}
+
+run_backup() {
+    local source=$1
+    local label=$2
+    local existing_manual patch resource_version source_json status token rc
+
+    token="task-$(date -u +%Y%m%dT%H%M%S)-$$"
+    source_json=$(kubectl --context "${CONTEXT}" -n "${NAMESPACE}" \
+        get replicationsource "${source}" -o json)
+    status=$(jq -r '[.status.conditions[]?
+        | select(.type == "Synchronizing")
+        | .status] | last // "Missing"' <<<"${source_json}")
+    [[ ${status} == "False" ]] || \
+        fail "${source} Synchronizing status is ${status}; refusing to overlap backups"
+
+    existing_manual=$(jq -r '.spec.trigger.manual // ""' <<<"${source_json}")
+    [[ -z ${existing_manual} ]] || \
+        fail "${source} already has manual trigger ${existing_manual}; refusing to overwrite it"
+    resource_version=$(jq -r '.metadata.resourceVersion' <<<"${source_json}")
+    patch=$(jq -cn --arg rv "${resource_version}" --arg token "${token}" '[
+        {"op":"test","path":"/metadata/resourceVersion","value":$rv},
+        {"op":"add","path":"/spec/trigger/manual","value":$token}
+    ]')
+
+    echo "Triggering ${label} backup for ${APP} in ${NAMESPACE} with token ${token}..."
+    cleanup_source=${source}
+    cleanup_token=${token}
+    if ! kubectl --context "${CONTEXT}" -n "${NAMESPACE}" \
+        patch replicationsource "${source}" --type json -p "${patch}"; then
+        cleanup_manual_trigger || \
+            fail "${source} trigger patch failed ambiguously and cleanup did not complete"
+        fail "${source} changed concurrently; no manual trigger was created"
+    fi
+
+    rc=0
+    bash "${SCRIPT_DIR}/wait-for-replicationsource.sh" \
+        "${source}" "${NAMESPACE}" "${token}" "${TIMEOUT}" || rc=$?
+    cleanup_manual_trigger || return 1
+    return "${rc}"
+}
+
+[[ -n ${APP} ]] || fail "Application name not specified"
+[[ ${TYPE} =~ ^(kopia|r2|all)$ ]] || fail "Type must be kopia, r2, or all"
+[[ ${TIMEOUT} =~ ^[1-9][0-9]*$ ]] || fail "Timeout must be a positive integer"
+
+trap on_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [[ ${TYPE} == "kopia" || ${TYPE} == "all" ]]; then
+    run_backup "${APP}" Kopia
+fi
+if [[ ${TYPE} == "r2" || ${TYPE} == "all" ]]; then
+    bash "${SCRIPT_DIR}/preflight-r2-operation.sh" "${APP}" "${NAMESPACE}" exclusive
+    run_backup "${APP}-r2" R2
+fi

--- a/.taskfiles/VolSync/scripts/wait-for-operation-job.sh
+++ b/.taskfiles/VolSync/scripts/wait-for-operation-job.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly CONTEXT="admin@home-kubernetes"
+
+JOB="${1:-}"
+NAMESPACE="${2:-default}"
+TIMEOUT="${3:-600}"
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+kubectl_cmd() {
+    kubectl --context "${CONTEXT}" "$@"
+}
+
+show_diagnostics() {
+    echo "--- Job logs ---" >&2
+    kubectl_cmd -n "${NAMESPACE}" logs "job/${JOB}" \
+        --all-containers=true --prefix=true >&2 2>/dev/null || true
+    echo "--- Job description ---" >&2
+    kubectl_cmd -n "${NAMESPACE}" describe job "${JOB}" >&2 2>/dev/null || true
+    echo "--- Recent Job events ---" >&2
+    kubectl_cmd -n "${NAMESPACE}" get events \
+        --field-selector "involvedObject.kind=Job,involvedObject.name=${JOB}" \
+        --sort-by='.lastTimestamp' >&2 2>/dev/null || true
+}
+
+[[ -n ${JOB} ]] || fail "Job name not specified"
+[[ ${TIMEOUT} =~ ^[1-9][0-9]*$ ]] || fail "Timeout must be a positive integer"
+
+start=$(date +%s)
+deadline=$((start + TIMEOUT))
+last_progress=${start}
+
+echo "Waiting for Job ${NAMESPACE}/${JOB} via ${CONTEXT} (timeout: ${TIMEOUT}s)..."
+
+while true; do
+    now=$(date +%s)
+    if (( now >= deadline )); then
+        echo "Timed out waiting for Job ${NAMESPACE}/${JOB}" >&2
+        show_diagnostics
+        exit 1
+    fi
+
+    if ! kubectl_cmd -n "${NAMESPACE}" get job "${JOB}" >/dev/null 2>&1; then
+        if (( now - last_progress >= 30 )); then
+            echo "Still waiting for Job creation ($((now - start))s elapsed)..."
+            last_progress=${now}
+        fi
+        sleep 2
+        continue
+    fi
+
+    complete=$(kubectl_cmd -n "${NAMESPACE}" get job "${JOB}" \
+        -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null || true)
+    failed=$(kubectl_cmd -n "${NAMESPACE}" get job "${JOB}" \
+        -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)
+
+    if [[ ${complete} == "True" ]]; then
+        echo "Job ${NAMESPACE}/${JOB} completed successfully."
+        kubectl_cmd -n "${NAMESPACE}" logs "job/${JOB}" \
+            --all-containers=true --prefix=true
+        exit 0
+    fi
+
+    if [[ ${failed} == "True" ]]; then
+        echo "Job ${NAMESPACE}/${JOB} failed." >&2
+        show_diagnostics
+        exit 1
+    fi
+
+    if (( now - last_progress >= 30 )); then
+        active=$(kubectl_cmd -n "${NAMESPACE}" get job "${JOB}" \
+            -o jsonpath='{.status.active}' 2>/dev/null || true)
+        succeeded=$(kubectl_cmd -n "${NAMESPACE}" get job "${JOB}" \
+            -o jsonpath='{.status.succeeded}' 2>/dev/null || true)
+        failures=$(kubectl_cmd -n "${NAMESPACE}" get job "${JOB}" \
+            -o jsonpath='{.status.failed}' 2>/dev/null || true)
+        echo "Still waiting ($((now - start))s elapsed; active=${active:-0}, succeeded=${succeeded:-0}, failed=${failures:-0})..."
+        last_progress=${now}
+    fi
+
+    sleep 2
+done

--- a/.taskfiles/VolSync/scripts/wait-for-replicationsource.sh
+++ b/.taskfiles/VolSync/scripts/wait-for-replicationsource.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly CONTEXT="admin@home-kubernetes"
+
+SOURCE="${1:-}"
+NAMESPACE="${2:-default}"
+TOKEN="${3:-}"
+TIMEOUT="${4:-7200}"
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+kubectl_cmd() {
+    kubectl --context "${CONTEXT}" "$@"
+}
+
+[[ -n ${SOURCE} ]] || fail "ReplicationSource name not specified"
+[[ -n ${TOKEN} ]] || fail "Manual trigger token not specified"
+[[ ${TIMEOUT} =~ ^[1-9][0-9]*$ ]] || fail "Timeout must be a positive integer"
+
+start=$(date +%s)
+deadline=$((start + TIMEOUT))
+last_progress=${start}
+
+echo "Waiting for ReplicationSource ${NAMESPACE}/${SOURCE} token ${TOKEN} (timeout: ${TIMEOUT}s)..."
+
+while true; do
+    now=$(date +%s)
+    if (( now >= deadline )); then
+        echo "Timed out waiting for ReplicationSource ${NAMESPACE}/${SOURCE}" >&2
+        kubectl_cmd -n "${NAMESPACE}" get replicationsource "${SOURCE}" -o yaml >&2 || true
+        exit 1
+    fi
+
+    source_json=$(kubectl_cmd -n "${NAMESPACE}" get replicationsource "${SOURCE}" -o json)
+    last_manual=$(jq -r '.status.lastManualSync // ""' <<<"${source_json}")
+    result=$(jq -r '.status.latestMoverStatus.result // ""' <<<"${source_json}")
+
+    if [[ ${last_manual} == "${TOKEN}" ]]; then
+        logs=$(jq -r '.status.latestMoverStatus.logs // ""' <<<"${source_json}")
+        if [[ ${result} == "Successful" ]]; then
+            echo "ReplicationSource ${NAMESPACE}/${SOURCE} completed successfully."
+            [[ -z ${logs} ]] || printf '%s\n' "${logs}"
+            exit 0
+        fi
+
+        if [[ ${result} == "Failed" ]]; then
+            echo "ReplicationSource ${NAMESPACE}/${SOURCE} failed." >&2
+            [[ -z ${logs} ]] || printf '%s\n' "${logs}" >&2
+            exit 1
+        fi
+    fi
+
+    if (( now - last_progress >= 30 )); then
+        echo "Still waiting ($((now - start))s elapsed; last token=${last_manual:-none}, result=${result:-pending})..."
+        last_progress=${now}
+    fi
+
+    sleep 5
+done

--- a/.taskfiles/VolSync/templates/debug.tmpl.yaml
+++ b/.taskfiles/VolSync/templates/debug.tmpl.yaml
@@ -1,20 +1,47 @@
-#file: noinspection KubernetesUnknownValues
 ---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/pod-v1.json
 apiVersion: v1
 kind: Pod
 metadata:
   name: ${job}
   namespace: ${ns}
+  labels:
+    app.kubernetes.io/name: volsync-r2-debug
+    app.kubernetes.io/managed-by: taskfile
+    home-ops.petrovic.io/volsync-app: ${app}
 spec:
   automountServiceAccountToken: false
   restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-    - name: main
+    - name: r2
       # renovate: datasource=docker depName=restic/restic
-      image: docker.io/restic/restic:0.16.4
-      command: ["/bin/sh"]
-      args: ["-c", "sleep infinity"]
+      image: mirror.gcr.io/restic/restic:0.19.1@sha256:136600b6ff6843d61d355f7f71f460a166429f35de6fd11b568fece3c9a4d510
+      command: ["/bin/sh", "-c"]
+      args: ["sleep infinity"]
       envFrom:
         - secretRef:
-            name: ${app}-volsync-secret
-      resources: {}
+            name: ${app}-volsync-r2-secret
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        readOnlyRootFilesystem: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  volumes:
+    - name: tmp
+      emptyDir: {}

--- a/.taskfiles/VolSync/templates/list.tmpl.yaml
+++ b/.taskfiles/VolSync/templates/list.tmpl.yaml
@@ -1,10 +1,13 @@
 ---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/job-batch-v1.json
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: ${job}
   namespace: ${ns}
 spec:
+  activeDeadlineSeconds: ${timeout}
+  backoffLimit: 0
   ttlSecondsAfterFinished: 3600
   template:
     spec:
@@ -13,7 +16,7 @@ spec:
       containers:
         - name: main
           # renovate: datasource=docker depName=ghcr.io/perfectra1n/volsync
-          image: ghcr.io/perfectra1n/volsync:v0.17.11
+          image: ghcr.io/perfectra1n/volsync:v0.17.11@sha256:79674d3c48685e21cadaac8e0afd14268130a0a51a10c41a9dd65096c1434a0f
           command:
             - /bin/sh
             - -c

--- a/.taskfiles/VolSync/templates/locks-r2.tmpl.yaml
+++ b/.taskfiles/VolSync/templates/locks-r2.tmpl.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ${job}
   namespace: ${ns}
   labels:
-    app.kubernetes.io/name: volsync-r2-check
+    app.kubernetes.io/name: volsync-r2-locks
     app.kubernetes.io/managed-by: taskfile
     home-ops.petrovic.io/volsync-app: ${app}
 spec:
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: volsync-r2-check
+        app.kubernetes.io/name: volsync-r2-locks
         app.kubernetes.io/managed-by: taskfile
         home-ops.petrovic.io/volsync-app: ${app}
     spec:
@@ -32,11 +32,22 @@ spec:
         - name: r2
           # renovate: datasource=docker depName=restic/restic
           image: mirror.gcr.io/restic/restic:0.19.1@sha256:136600b6ff6843d61d355f7f71f460a166429f35de6fd11b568fece3c9a4d510
+          command: ["/bin/sh", "-c"]
           args:
-            - --no-cache
-            - --stuck-request-timeout
-            - 2m
-            - check
+            - |
+              set -eu
+              locks="$(restic --no-cache --no-lock --stuck-request-timeout 2m list locks)"
+              if [ -z "${locks}" ]; then
+                  echo "No Restic locks found."
+                  exit 0
+              fi
+
+              set -- ${locks}
+              echo "Found $# Restic lock(s):"
+              for lock in "$@"; do
+                  echo "--- ${lock} ---"
+                  restic --no-cache --no-lock --stuck-request-timeout 2m cat lock "${lock}"
+              done
           envFrom:
             - secretRef:
                 name: ${app}-volsync-r2-secret
@@ -48,10 +59,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 64Mi
+              memory: 32Mi
             limits:
-              cpu: 500m
-              memory: 512Mi
+              cpu: 100m
+              memory: 128Mi
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/.taskfiles/VolSync/templates/unlock.tmpl.yaml
+++ b/.taskfiles/VolSync/templates/unlock.tmpl.yaml
@@ -1,30 +1,98 @@
-#file: noinspection KubernetesUnknownValues,KubernetesUnknownValues
 ---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/job-batch-v1.json
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: ${job}
   namespace: ${ns}
+  labels:
+    app.kubernetes.io/name: volsync-r2-unlock
+    app.kubernetes.io/managed-by: taskfile
+    home-ops.petrovic.io/volsync-app: ${app}
 spec:
+  activeDeadlineSeconds: ${timeout}
+  backoffLimit: 0
   ttlSecondsAfterFinished: 3600
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: volsync-r2-unlock
+        app.kubernetes.io/managed-by: taskfile
+        home-ops.petrovic.io/volsync-app: ${app}
     spec:
       automountServiceAccountToken: false
-      restartPolicy: OnFailure
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - name: garage
-          # renovate: datasource=docker depName=restic/restic
-          image: docker.io/restic/restic:0.16.4
-          args: ["unlock", "--remove-all"]
-          envFrom:
-            - secretRef:
-                name: ${app}-volsync-secret
-          resources: {}
         - name: r2
           # renovate: datasource=docker depName=restic/restic
-          image: docker.io/restic/restic:0.16.4
-          args: ["unlock", "--remove-all"]
+          image: mirror.gcr.io/restic/restic:0.19.1@sha256:136600b6ff6843d61d355f7f71f460a166429f35de6fd11b568fece3c9a4d510
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+
+              list_locks() {
+                  restic --no-cache --no-lock --stuck-request-timeout 2m list locks
+              }
+
+              show_locks() {
+                  lock_ids="$1"
+                  [ -n "${lock_ids}" ] || return 0
+                  set -- ${lock_ids}
+                  for lock in "$@"; do
+                      echo "--- ${lock} ---"
+                      restic --no-cache --no-lock --stuck-request-timeout 2m cat lock "${lock}"
+                  done
+              }
+
+              before="$(list_locks)"
+              if [ -z "${before}" ]; then
+                  echo "No Restic locks found; unlock is a no-op."
+                  exit 0
+              fi
+
+              set -- ${before}
+              before_count=$#
+              echo "Found ${before_count} lock(s) before stale-only unlock:"
+              show_locks "${before}"
+
+              echo "Running plain 'restic unlock'; non-stale locks will not be removed."
+              restic --no-cache --stuck-request-timeout 2m unlock
+
+              after="$(list_locks)"
+              if [ -n "${after}" ]; then
+                  set -- ${after}
+                  echo "ERROR: $# lock(s) remain after stale-only unlock:" >&2
+                  show_locks "${after}" >&2
+                  echo "Refusing to force-remove remaining locks; investigate their owners." >&2
+                  exit 1
+              fi
+
+              echo "Removed ${before_count} stale lock(s); no locks remain."
           envFrom:
             - secretRef:
                 name: ${app}-volsync-r2-secret
-          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/README.md
+++ b/README.md
@@ -288,11 +288,12 @@ task bootstrap:verify         # Verify the core bootstrap substrate
 task bootstrap:verify-full    # Verify full GitOps/storage/app convergence
 
 # Volume backup operations
-task volsync:check            # Check volsync repo (requires: app=<name>)
-task volsync:debug            # Debug restic (requires: app=<name>)
-task volsync:list             # List snapshots (requires: app=<name>)
-task volsync:unlock           # Unlock restic repository (requires: app=<name>)
-task volsync:snapshot         # Create snapshot (requires: app=<name>)
+task volsync:list             # List primary Kopia snapshots (requires: app=<name>)
+task volsync:backup           # Trigger and verify Kopia/R2 backup (requires: app=<name>)
+task volsync:locks-r2         # Inspect R2 Restic locks (requires: app=<name>)
+task volsync:unlock-r2        # Safely remove stale R2 locks (requires: app=<name>)
+task volsync:check-r2         # Check R2 Restic metadata (requires: app=<name>)
+task volsync:debug-r2         # Create an R2 Restic debug Pod (requires: app=<name>)
 task volsync:restore          # Restore from snapshot (requires: app=<name>)
 task volsync:cleanup          # Delete volume populator PVCs
 

--- a/docs/agent/operations.md
+++ b/docs/agent/operations.md
@@ -41,10 +41,17 @@ VolSync:
 
 ```bash
 task volsync:list app=<name> ns=<namespace>
-task volsync:snapshot app=<name> ns=<namespace>
+task volsync:backup app=<name> ns=<namespace> type=<kopia|r2|all>
+task volsync:locks-r2 app=<name> ns=<namespace>
+task volsync:unlock-r2 app=<name> ns=<namespace> verify=<false|true>
+task volsync:check-r2 app=<name> ns=<namespace>
+task volsync:debug-r2 app=<name> ns=<namespace>
 task volsync:restore app=<name> ns=<namespace>
-task volsync:unlock app=<name> ns=<namespace>
 ```
+
+R2 lock recovery is deliberately stale-only: `unlock-r2` runs plain `restic unlock`
+after checking for active repository owners. It has no `--remove-all` or force mode.
+All R2 operational tasks pin the `admin@home-kubernetes` context.
 
 ## GitOps Reconciliation
 

--- a/kubernetes/components/volsync/README.md
+++ b/kubernetes/components/volsync/README.md
@@ -119,6 +119,54 @@ kubectl get kopiamaintenance -A
 # Navigate to kopia.<your-domain>
 ```
 
+### Safe R2 Lock Recovery
+
+Cloudflare R2 is the only Restic backend. Inspect repository locks before changing
+them:
+
+```bash
+task volsync:locks-r2 app=home-assistant ns=automation
+```
+
+Remove only locks that Restic identifies as stale:
+
+```bash
+task volsync:unlock-r2 app=home-assistant ns=automation
+```
+
+To immediately prove the repository can complete a new backup after unlocking:
+
+```bash
+task volsync:unlock-r2 app=home-assistant ns=automation verify=true
+```
+
+The unlock task pins the `admin@home-kubernetes` context, targets only
+`${APP}-volsync-r2-secret`, and refuses to run while a mover or another Pod may
+own a legitimate lock. It runs plain `restic unlock`; there is intentionally no
+`--remove-all` or force mode. Remaining locks require investigation.
+
+Operation Jobs are deleted after success and retained for up to one hour after
+failure so their logs and events remain available. A failed Job blocks another
+operation for the same app until it expires or is deliberately removed:
+
+```bash
+kubectl --context admin@home-kubernetes -n automation \
+  delete job volsync-r2-unlock-home-assistant
+```
+
+Run repository recoveries sequentially by default. If several repositories are
+known to be idle, use no more than two concurrent inspection/unlock operations
+and only one `verify=true` backup at a time. Manual backup triggers are removed
+atomically after completion so the configured schedule resumes; cleanup failure
+fails the task and prints an exact recovery command.
+
+A metadata-only repository check is also available, but it may be slow and incur
+R2 API/download costs:
+
+```bash
+task volsync:check-r2 app=home-assistant ns=automation
+```
+
 ### Kopia Web UI
 
 The Kopia server provides a web interface for browsing and managing backups. It connects to the same NFS-backed repository that the VolSync movers use.
@@ -155,9 +203,9 @@ kubectl -n "${ns}" get secret "${app}-volsync-r2-secret"
 Optionally inspect R2 snapshots directly with Restic:
 
 ```bash
-kubectl -n "${ns}" run "restic-list-${app}" \
+kubectl --context admin@home-kubernetes -n "${ns}" run "restic-list-${app}" \
   --rm -it --restart=Never \
-  --image=docker.io/restic/restic:0.16.4 \
+  --image=mirror.gcr.io/restic/restic:0.19.1@sha256:136600b6ff6843d61d355f7f71f460a166429f35de6fd11b568fece3c9a4d510 \
   --env-from="secretRef/name=${app}-volsync-r2-secret" \
   -- snapshots
 ```


### PR DESCRIPTION
## Summary
- replace the stale two-backend force-unlock task with R2-only lock inspection and stale-only unlock Jobs
- add active-owner preflights, pinned cluster context, bounded Job waiters, immutable Restic image, and hardened Pod security
- make manual backup triggers concurrency-safe, wait by exact token, and atomically restore scheduled triggers
- retain deprecated task aliases and document the operational runbook

## Safety
- no `--remove-all` or force path
- only `${app}-volsync-r2-secret` is passed to Restic
- active/ambiguous repository owners block exclusive operations
- remaining non-stale locks fail closed
- failed manual-trigger cleanup fails the task and prints an exact recovery command

## Validation
- Bash syntax and ShellCheck passed for all VolSync scripts
- normalized Taskfile passed the Task schema
- rendered Jobs/Pod passed Kubernetes 1.36 strict schemas and server-side dry-run
- fixture tests covered preflight blockers, waiter success/failure, trigger concurrency, ambiguous patch responses, backup failure, and cleanup failure
- live-tested on `default/hister`: read-only lock inspection, no-op stale-only unlock, R2 backup, compatibility alias, and hardened debug Pod
- live-tested optimistic manual trigger + cleanup on `default/actual-budget`
- all test resources cleaned up; schedules restored; Flux Ready; NodeSystemSaturation not firing
