### PR TITLE
fix(volsync): decouple R2 and protect AdGuard replicas

### DIFF
--- a/kubernetes/apps/network/adguard/README.md
+++ b/kubernetes/apps/network/adguard/README.md
@@ -83,6 +83,86 @@ Observed pod-deletion failover test:
 - TCP DNS had no observed interruption.
 - UDP DNS and DoH each saw one short transient miss before continuing through the surviving pod.
 
+## Backup and restore
+
+The generic VolSync component continues to protect the `adguard` seed PVC. It does
+not cover live writes after the StatefulSet creates `data-adguard-0` and
+`data-adguard-1`, so `app/backups.yaml` defines independent hourly Kopia and daily
+R2/Restic `ReplicationSource` resources for both active PVCs.
+
+The ordinal Kopia sources share `adguard-volsync-secret` but have distinct source
+identities (`adguard-0` and `adguard-1`). R2 uses separate repository secrets and
+paths. The generic `task volsync:restore app=...` helper is therefore not suitable
+for these PVCs.
+
+To restore an ordinal, first suspend reconciliation and stop both AdGuard
+controllers so no process writes either PVC:
+
+```bash
+flux -n network suspend kustomization adguard
+flux -n network suspend helmrelease adguard
+kubectl -n network scale statefulset/adguard deployment/adguard-sync --replicas=0
+```
+
+For Kopia, apply a temporary direct destination, replacing `N` with `0` or `1`:
+
+```yaml
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: adguard-N-restore
+  namespace: network
+spec:
+  trigger:
+    manual: restore-once
+  kopia:
+    repository: adguard-volsync-secret
+    destinationPVC: data-adguard-N
+    copyMethod: Direct
+    sourceIdentity:
+      sourceName: adguard-N
+    moverSecurityContext:
+      runAsUser: 1001
+      runAsGroup: 568
+      fsGroup: 1001
+      fsGroupChangePolicy: OnRootMismatch
+```
+
+For R2, use the same destination name and PVC with a `restic` block instead:
+
+```yaml
+  restic:
+    repository: adguard-N-volsync-r2-secret
+    destinationPVC: data-adguard-N
+    copyMethod: Direct
+    cacheCapacity: 4Gi
+    cacheStorageClassName: openebs-hostpath
+    cacheAccessModes: [ReadWriteOnce]
+    enableFileDeletion: true
+    moverSecurityContext:
+      runAsUser: 1001
+      runAsGroup: 1001
+      fsGroup: 1001
+      fsGroupChangePolicy: OnRootMismatch
+```
+
+Save the selected resource as `/tmp/adguard-restore.yaml`, replace every `N`, then
+run:
+
+```bash
+kubectl apply -f /tmp/adguard-restore.yaml
+bash .taskfiles/VolSync/scripts/wait-for-replicationdestination.sh \
+  adguard-N-restore network 7200
+kubectl -n network delete replicationdestination adguard-N-restore
+flux -n network resume helmrelease adguard
+flux -n network resume kustomization adguard
+kubectl -n network rollout status statefulset/adguard --timeout=10m
+dig @10.0.88.53 example.com
+```
+
+Restore both ordinals only when both active copies are known bad; otherwise restore
+one and let `adguardhome-sync` repopulate synchronized settings.
+
 ## Useful checks
 
 ```bash
@@ -110,5 +190,6 @@ doggo example.com A @tls://10.0.88.53 --tls-hostname=dns.${SECRET_DOMAIN} --shor
 
 - `ks.yaml` — Flux Kustomization for AdGuard.
 - `app/helmrelease.yaml` — StatefulSet, Services, sync controller, probes, and resource settings.
+- `app/backups.yaml` — per-ordinal Kopia and R2 protection for both active PVCs.
 - `app/externalsecret.yaml` — native AdGuard credentials for `adguardhome-sync` from 1Password.
 - `app/certificate.yaml` — TLS certificate used by DNS-over-HTTPS / DNS-over-TLS.

--- a/kubernetes/apps/network/adguard/app/backups.yaml
+++ b/kubernetes/apps/network/adguard/app/backups.yaml
@@ -1,0 +1,158 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: adguard-0
+spec:
+  sourcePVC: data-adguard-0
+  trigger:
+    schedule: "37 * * * *"
+  kopia:
+    accessModes: [ReadWriteOnce]
+    compression: zstd-fastest
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 1001
+      runAsGroup: 568
+      fsGroup: 1001
+      fsGroupChangePolicy: OnRootMismatch
+    parallelism: 2
+    repository: adguard-volsync-secret
+    retain:
+      hourly: 24
+      daily: 7
+    storageClassName: ceph-block
+    volumeSnapshotClassName: csi-ceph-blockpool
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: adguard-1
+spec:
+  sourcePVC: data-adguard-1
+  trigger:
+    schedule: "47 * * * *"
+  kopia:
+    accessModes: [ReadWriteOnce]
+    compression: zstd-fastest
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 1001
+      runAsGroup: 568
+      fsGroup: 1001
+      fsGroupChangePolicy: OnRootMismatch
+    parallelism: 2
+    repository: adguard-volsync-secret
+    retain:
+      hourly: 24
+      daily: 7
+    storageClassName: ceph-block
+    volumeSnapshotClassName: csi-ceph-blockpool
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: adguard-0-volsync-r2
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: adguard-0-volsync-r2-secret
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/adguard-0"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: cloudflare-r2-volsync
+    - extract:
+        key: volsync-r2-template
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: adguard-0-r2
+spec:
+  sourcePVC: data-adguard-0
+  trigger:
+    schedule: "58 5 * * *"
+  restic:
+    copyMethod: Snapshot
+    pruneIntervalDays: 7
+    repository: adguard-0-volsync-r2-secret
+    volumeSnapshotClassName: csi-ceph-blockpool
+    cacheCapacity: 4Gi
+    cacheStorageClassName: openebs-hostpath
+    cacheAccessModes: [ReadWriteOnce]
+    storageClassName: ceph-block
+    accessModes: [ReadWriteOnce]
+    moverSecurityContext:
+      runAsUser: 1001
+      runAsGroup: 1001
+      fsGroup: 1001
+      fsGroupChangePolicy: OnRootMismatch
+    retain:
+      daily: 7
+      weekly: 1
+      monthly: 1
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: adguard-1-volsync-r2
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: adguard-1-volsync-r2-secret
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/adguard-1"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: cloudflare-r2-volsync
+    - extract:
+        key: volsync-r2-template
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: adguard-1-r2
+spec:
+  sourcePVC: data-adguard-1
+  trigger:
+    schedule: "8 6 * * *"
+  restic:
+    copyMethod: Snapshot
+    pruneIntervalDays: 7
+    repository: adguard-1-volsync-r2-secret
+    volumeSnapshotClassName: csi-ceph-blockpool
+    cacheCapacity: 4Gi
+    cacheStorageClassName: openebs-hostpath
+    cacheAccessModes: [ReadWriteOnce]
+    storageClassName: ceph-block
+    accessModes: [ReadWriteOnce]
+    moverSecurityContext:
+      runAsUser: 1001
+      runAsGroup: 1001
+      fsGroup: 1001
+      fsGroupChangePolicy: OnRootMismatch
+    retain:
+      daily: 7
+      weekly: 1
+      monthly: 1

--- a/kubernetes/apps/network/adguard/app/helmrelease.yaml
+++ b/kubernetes/apps/network/adguard/app/helmrelease.yaml
@@ -51,9 +51,9 @@ spec:
               storageClass: ceph-block
               accessMode: ReadWriteOnce
               size: 5Gi
-              # Clone the current single-pod PVC into each StatefulSet ordinal
-              # on first creation. Keep the old `adguard` PVC around for rollback
-              # until the active/active setup is validated.
+              # Clone the seed PVC into each StatefulSet ordinal on first creation.
+              # `backups.yaml` protects both active ordinal PVCs independently;
+              # keep the old `adguard` PVC as bootstrap/rollback state.
               dataSource:
                 kind: PersistentVolumeClaim
                 name: adguard

--- a/kubernetes/apps/network/adguard/app/kustomization.yaml
+++ b/kubernetes/apps/network/adguard/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: network
 resources:
+  - ./backups.yaml
   - ./certificate.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
@@ -85,6 +85,9 @@ spec:
     - name: has-volsync-created-by-labels
       expression: >-
         object.metadata.?labels["app.kubernetes.io/created-by"].orValue("") == "volsync"
+    - name: has-kopia-mover-container
+      expression: >-
+        object.spec.template.spec.containers.exists(container, container.name == "kopia")
     - name: repository-volume-does-not-exist
       expression: >-
         !has(object.spec.template.spec.volumes) ||

--- a/kubernetes/components/volsync/README.md
+++ b/kubernetes/components/volsync/README.md
@@ -5,13 +5,13 @@ VolSync is a Kubernetes operator that provides automated backup and restore capa
 This VolSync setup uses a dual-storage strategy:
 
 - **Kopia (Primary)**: Frequent backups (hourly) stored in a Kopia filesystem repository on NFS (`/volume2/kopia`)
-- **Cloudflare R2 (Secondary)**: Daily backups stored in Cloudflare R2 via restic for disaster recovery
+- **Cloudflare R2 (Secondary)**: Daily backups stored in Cloudflare R2 via restic for disaster recovery; mover jobs do not mount or depend on the Kopia NFS repository
 
 ### Thundering Herd Prevention
 
 All Kopia backups share a single cron schedule (`0 * * * *`). A `MutatingAdmissionPolicy` (`volsync-mover-jitter`) automatically injects a random 0-30 second sleep as an init container into every VolSync source job, spreading out the actual backup starts across a 30-second window.
 
-A second `MutatingAdmissionPolicy` (`volsync-mover-nfs`) dynamically injects the NFS volume mount for the Kopia repository into every VolSync mover job, keeping the component configuration clean.
+A second `MutatingAdmissionPolicy` (`volsync-mover-nfs`) dynamically injects the NFS volume only into jobs that contain a Kopia mover container. Restic/R2 movers are deliberately excluded so the secondary backup path remains independent of NAS availability.
 
 ### Core Components
 
@@ -67,7 +67,7 @@ spec:
       VOLSYNC_CAPACITY: 10Gi
 ```
 
-That's it for Kopia backups — no schedule configuration needed. The hourly schedule and jitter are handled automatically.
+That's it for a workload whose live data is stored in `${APP}`. The hourly schedule and jitter are handled automatically. StatefulSet `volumeClaimTemplates` create different PVC names and require explicit per-ordinal `ReplicationSource` resources; see `kubernetes/apps/network/adguard/app/backups.yaml`.
 
 ### Step 2: Optional R2 Schedule Override
 

--- a/kubernetes/components/volsync/r2.yaml
+++ b/kubernetes/components/volsync/r2.yaml
@@ -44,7 +44,7 @@ spec:
     accessModes: ["${VOLSYNC_ACCESSMODES:-ReadWriteOnce}"]
     moverSecurityContext:
       runAsUser: ${VOLSYNC_UID:-568}
-      runAsGroup: 568 # Injected Kopia NFS repository group
+      runAsGroup: ${VOLSYNC_GID:-568}
       fsGroup: ${VOLSYNC_GID:-568}
       fsGroupChangePolicy: OnRootMismatch
     retain:


### PR DESCRIPTION
## Summary
- restrict Kopia NFS injection to VolSync jobs that actually contain a `kopia` mover
- keep Restic/R2 movers independent of Synology/NFS and honor per-app group overrides
- add hourly Kopia and daily R2 backups for both live AdGuard StatefulSet PVCs
- document exact per-ordinal Kopia/R2 restore procedures

## Why
The migration audit found that the broad admission policy could make R2 jobs depend on the NAS, and that generic AdGuard VolSync protected only the seed PVC rather than `data-adguard-0` and `data-adguard-1`.

## Validation
- Kustomize renders for AdGuard and VolSync
- server-side dry-run validates the new ReplicationSources, ExternalSecrets, and CEL admission policy
- Kustomization schema and multi-document YAML parsing pass

## Post-merge verification
- wait for all four new per-ordinal backups to complete
- inspect a live Restic mover and confirm it has no `repository` NFS volume or `/repository` mount
- perform a disposable restore test for each AdGuard ordinal before migration quiescence
