### PR TITLE
chore(volsync): pause Synology Kopia backups

### DIFF
--- a/kubernetes/apps/network/adguard/app/backups.yaml
+++ b/kubernetes/apps/network/adguard/app/backups.yaml
@@ -5,6 +5,8 @@ kind: ReplicationSource
 metadata:
   name: adguard-0
 spec:
+  # Temporarily pause Synology-backed Kopia writes during the NAS migration.
+  paused: true
   sourcePVC: data-adguard-0
   trigger:
     schedule: "37 * * * *"
@@ -31,6 +33,8 @@ kind: ReplicationSource
 metadata:
   name: adguard-1
 spec:
+  # Temporarily pause Synology-backed Kopia writes during the NAS migration.
+  paused: true
   sourcePVC: data-adguard-1
   trigger:
     schedule: "47 * * * *"

--- a/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
@@ -6,6 +6,8 @@ metadata:
   name: daily
 spec:
   enabled: true
+  # Temporarily prevent new maintenance during the NAS migration.
+  suspend: true
   activeDeadlineSeconds: 43200
   podSecurityContext:
     runAsUser: 0

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -5,6 +5,8 @@ kind: ReplicationSource
 metadata:
   name: ${APP}
 spec:
+  # Temporarily pause Synology-backed Kopia writes during the NAS migration.
+  paused: true
   sourcePVC: ${APP}
   trigger:
     schedule: "${VOLSYNC_KOPIA_SCHEDULE:-0 * * * *}"


### PR DESCRIPTION
## Summary
- pause all shared Synology-backed Kopia ReplicationSources
- pause the two explicit AdGuard Kopia ReplicationSources
- suspend new Kopia repository maintenance jobs
- leave in-flight jobs and independent R2 backups untouched

## Why
Reduce Synology I/O and Kopia repository churn while the retained dataset is copied to the UNAS staging disks. These pauses are temporary and will be reversed at the migration backup gate.

## Validation
- rendered shared ReplicationSource with `flux envsubst`
- schema-validated rendered shared ReplicationSource
- schema-validated both AdGuard ReplicationSource documents
- schema-validated KopiaMaintenance
