### PR TITLE
fix(frigate): resume NFS recordings

### DIFF
--- a/kubernetes/apps/automation/frigate/app/config/config.yml
+++ b/kubernetes/apps/automation/frigate/app/config/config.yml
@@ -98,7 +98,17 @@ camera_groups:
       - front_yard
 
 record:
-  enabled: false
+  enabled: true
+  alerts:
+    pre_capture: 5
+    post_capture: 5
+    retain:
+      days: 30
+      mode: motion
+  detections:
+    retain:
+      days: 30
+      mode: motion
 
 review:
   genai:

--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -133,8 +133,9 @@ spec:
         globalMounts:
           - path: /dev/bus/usb
       media:
-        type: emptyDir
-        sizeLimit: 10Gi
+        type: nfs
+        server: ${SECRET_NFS_DOMAIN}
+        path: /volume2/k8s/frigate
         globalMounts:
           - path: /media
 


### PR DESCRIPTION
## Summary
- restore Frigate's `/volume2/k8s/frigate` NFS mount at `/media`
- re-enable motion-based alert and detection recordings with 30-day retention
- treat recordings as disposable data excluded from the UNAS migration

## Validation
- `yq eval '.'` on both changed YAML files
- app-template HelmRelease JSON schema validation
- `kustomize build kubernetes/apps/automation/frigate/app`

## Note
- Commit is unsigned because the local 1Password SSH agent was unavailable; proceeding unsigned was explicitly approved.
