### PR TITLE
feat(gdb): restore database and scraper stack

### DIFF
--- a/kubernetes/apps/gdb/gdb/database/cluster.yaml
+++ b/kubernetes/apps/gdb/gdb/database/cluster.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: gdb-postgres
+  annotations:
+    cnpg.io/skipEmptyWalArchiveCheck: "enabled"
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgis:18.3-3.6.2-standard-bookworm
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: 80Gi
+    storageClass: openebs-hostpath
+  bootstrap:
+    initdb:
+      database: gdb
+      owner: gdb
+      secret:
+        name: gdb-postgres-app-secret
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS postgis
+        - CREATE EXTENSION IF NOT EXISTS pg_trgm
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: gdb-postgres-superuser-secret
+  postgresql:
+    parameters:
+      max_connections: "300"
+      shared_buffers: 1GB
+  nodeMaintenanceWindow:
+    inProgress: false
+    reusePVC: true
+  enablePDB: false
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      memory: 4Gi
+  monitoring:
+    enablePodMonitor: true
+    podMonitorMetricRelabelings:
+      - { sourceLabels: ["cluster"], targetLabel: cnpg_cluster, action: replace }
+      - { regex: cluster, action: labeldrop }
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: gdb-garage
+        serverName: gdb-postgres-v2

--- a/kubernetes/apps/gdb/gdb/database/externalsecret.yaml
+++ b/kubernetes/apps/gdb/gdb/database/externalsecret.yaml
@@ -1,0 +1,83 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gdb-postgres-app
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gdb-postgres-app-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        username: gdb
+        password: "{{ .POSTGRES_PASS }}"
+  data:
+    - secretKey: POSTGRES_PASS
+      remoteRef:
+        key: gdb
+        property: POSTGRES_PASS
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gdb-runtime
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gdb-runtime-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        DATABASE_URL: "postgresql://gdb:{{ .POSTGRES_PASS }}@gdb-postgres-rw.gdb.svc.cluster.local:5432/gdb?sslmode=disable"
+  data:
+    - secretKey: POSTGRES_PASS
+      remoteRef:
+        key: gdb
+        property: POSTGRES_PASS
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gdb-postgres-superuser
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gdb-postgres-superuser-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: cloudnative-pg
+        property: POSTGRES_SUPER_USER
+    - secretKey: password
+      remoteRef:
+        key: cloudnative-pg
+        property: POSTGRES_SUPER_PASS
+    - secretKey: aws-access-key-id
+      remoteRef:
+        key: cloudnative-pg
+        property: AWS_ACCESS_KEY_ID
+    - secretKey: aws-secret-access-key
+      remoteRef:
+        key: cloudnative-pg
+        property: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/gdb/gdb/database/kustomization.yaml
+++ b/kubernetes/apps/gdb/gdb/database/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml
+  - ./externalsecret.yaml
+  - ./objectstore.yaml
+  - ./scheduledbackup.yaml

--- a/kubernetes/apps/gdb/gdb/database/objectstore.yaml
+++ b/kubernetes/apps/gdb/gdb/database/objectstore.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://schemas.hydaz.com/barmancloud.cnpg.io/objectstore_v1.json
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: gdb-garage
+spec:
+  retentionPolicy: 14d
+  configuration:
+    destinationPath: s3://postgres/
+    endpointURL: https://s3.${SECRET_DOMAIN}
+    s3Credentials:
+      accessKeyId:
+        name: gdb-postgres-superuser-secret
+        key: aws-access-key-id
+      secretAccessKey:
+        name: gdb-postgres-superuser-secret
+        key: aws-secret-access-key
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    data:
+      compression: bzip2
+      jobs: 1
+      additionalCommandArgs:
+        - --max-archive-size=10GB
+        - --min-chunk-size=100MB
+        - --read-timeout=300

--- a/kubernetes/apps/gdb/gdb/database/scheduledbackup.yaml
+++ b/kubernetes/apps/gdb/gdb/database/scheduledbackup.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: gdb-postgres
+spec:
+  schedule: "0 30 2 * * *"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: gdb-postgres
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/gdb/gdb/ks.yaml
+++ b/kubernetes/apps/gdb/gdb/ks.yaml
@@ -1,0 +1,85 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gdb-postgres
+  namespace: &namespace gdb
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: database
+    - name: cloudnative-pg-barman-cloud
+      namespace: database
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: openebs
+      namespace: openebs-system
+  path: ./kubernetes/apps/gdb/gdb/database
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gdb-migration
+  namespace: &namespace gdb
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: gdb-postgres
+      namespace: gdb
+  path: ./kubernetes/apps/gdb/gdb/migration
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gdb-scraper
+  namespace: &namespace gdb
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: gdb-migration
+      namespace: gdb
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/apps/gdb/gdb/scraper
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/gdb/gdb/migration/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/migration/helmrelease.yaml
@@ -1,0 +1,73 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gdb-migration
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    force: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  interval: 30m
+  values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-private
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+    controllers:
+      migrate-v1-10-58:
+        type: job
+        job:
+          activeDeadlineSeconds: 3600
+          backoffLimit: 1
+        pod:
+          restartPolicy: Never
+        containers:
+          app:
+            image:
+              repository: ghcr.io/adampetrovic/gdb-web
+              tag: 1.10.58@sha256:bb88187032e94b35b7dc2ebb1777500ce4499c43319d9256d7e70b9fa7dacb02
+            command:
+              - /app/migrate.sh
+            env:
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: gdb-runtime-secret
+                    key: DATABASE_URL
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 250m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/gdb/gdb/migration/kustomization.yaml
+++ b/kubernetes/apps/gdb/gdb/migration/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/gdb/gdb/scraper/externalsecret.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/externalsecret.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gdb-scraper-proxy
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gdb-scraper-proxy-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: EXTERNAL_PROXY_URL
+      remoteRef:
+        key: gdb
+        property: EXTERNAL_PROXY_URL
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gdb-scraper-r2
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gdb-scraper-volsync-r2-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/gdb-scraper"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: cloudflare-r2-volsync
+    - extract:
+        key: volsync-r2-template

--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -1,0 +1,434 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gdb-scraper
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  interval: 30m
+  values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-private
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        runAsNonRoot: true
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups:
+          - 100
+    controllers:
+      usag-bootstrap:
+        type: cronjob
+        cronjob: &manualCronJob
+          schedule: "0 0 1 1 *"
+          timeZone: Australia/Sydney
+          suspend: true
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+          backoffLimit: 0
+        pod: &scraperPod
+          restartPolicy: Never
+        containers:
+          scraper:
+            image: &image
+              repository: ghcr.io/adampetrovic/gdb-scraper
+              tag: 0.1.83@sha256:33c11ce1547820692c1617c4d50c45274b9d13abd327b17c48a124586458d94b
+            env:
+              DATABASE_URL: &databaseUrl
+                valueFrom:
+                  secretKeyRef:
+                    name: gdb-runtime-secret
+                    key: DATABASE_URL
+              OUTPUT_DIR: /export
+              SOURCE: usag
+              MODE: full
+              CONCURRENCY: "50"
+            probes: &disabledProbes
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 250m
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+            securityContext: &containerSecurity
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+      mso-canary-fetch:
+        type: cronjob
+        cronjob: *manualCronJob
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            env:
+              OUTPUT_DIR: /export/canary/mso
+              SOURCE: mso
+              MODE: incremental
+              MSO_CACHE_MODE: fetch-cache
+              MSO_CACHE_DIR: /export/canary/mso/mso-cache
+              MSO_LOOKUP_CLUBS: "true"
+              LIMIT_MEETS: "1"
+              CONCURRENT_REQUESTS: "1"
+              CONCURRENT_REQUESTS_PER_DOMAIN: "1"
+              RETRY_TIMES: "0"
+              http_proxy: &externalProxy
+                valueFrom:
+                  secretKeyRef:
+                    name: gdb-scraper-proxy-secret
+                    key: EXTERNAL_PROXY_URL
+              https_proxy: *externalProxy
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+            securityContext: *containerSecurity
+      mso-bootstrap-fetch:
+        type: cronjob
+        cronjob: *manualCronJob
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            env:
+              OUTPUT_DIR: /export
+              SOURCE: mso
+              MODE: full
+              SEASONS: &msoBootstrapSeasons "2026-2027,2025-2026,2024-2025,2023-2024,2022-2023,2021-2022,2020-2021,2019-2020,2018-2019,2017-2018,2016-2017,2015-2016,2014-2015,2013-2014,2012-2013,2011-2012,2010-2011,2009-2010,2008-2009,2007-2008,2006-2007,2005-2006,2004-2005,2003-2004,2002-2003,2001-2002,2000-2001"
+              MSO_CACHE_MODE: fetch-cache
+              MSO_CACHE_DIR: /export/mso-cache
+              MSO_LOOKUP_CLUBS: "true"
+              CONCURRENT_REQUESTS: "5"
+              CONCURRENT_REQUESTS_PER_DOMAIN: "5"
+              http_proxy: *externalProxy
+              https_proxy: *externalProxy
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 250m
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+            securityContext: *containerSecurity
+      mso-bootstrap-replay:
+        type: cronjob
+        cronjob: *manualCronJob
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            command:
+              - /bin/bash
+              - -lc
+            args: &guardedReplay
+              - |-
+                set -euo pipefail
+                min_rows="${USAG_BOOTSTRAP_MIN_RAINBOW_ROWS:-1000000}"
+                rainbow_rows="$(psql "$DATABASE_URL" -Atc "SELECT count(*) FROM usagnum_hash_lookup" | tr -d '[:space:]')"
+                if [ "${rainbow_rows:-0}" -lt "$min_rows" ]; then
+                  echo "USAG bootstrap preflight failed: rainbow table has ${rainbow_rows:-0} rows; need at least ${min_rows}."
+                  exit 1
+                fi
+                exec /app/entrypoint.sh "$SOURCE"
+            env:
+              DATABASE_URL: *databaseUrl
+              OUTPUT_DIR: /export
+              SOURCE: mso
+              MODE: full
+              SEASONS: *msoBootstrapSeasons
+              MSO_CACHE_MODE: replay-cache
+              MSO_CACHE_DIR: /export/mso-cache
+              MSO_LOOKUP_CLUBS: "true"
+              GDB_DISABLE_NETWORK_FETCHES: "true"
+              MSO_OFFLINE_REPLAY: "true"
+              USAG_BOOTSTRAP_MIN_RAINBOW_ROWS: "1000000"
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 500m
+                memory: 4Gi
+              limits:
+                memory: 8Gi
+            securityContext: *containerSecurity
+      mms-canary-fetch:
+        type: cronjob
+        cronjob: *manualCronJob
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            env:
+              OUTPUT_DIR: /export/canary/mms
+              SOURCE: mms
+              MODE: incremental
+              MMS_CACHE_MODE: fetch-cache
+              MMS_CACHE_DIR: /export/canary/mms/mms-cache
+              LIMIT_MEETS: "1"
+              CONCURRENT_REQUESTS: "1"
+              CONCURRENT_REQUESTS_PER_DOMAIN: "1"
+              RETRY_TIMES: "0"
+              http_proxy: *externalProxy
+              https_proxy: *externalProxy
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+            securityContext: *containerSecurity
+      mms-bootstrap-fetch:
+        type: cronjob
+        cronjob: *manualCronJob
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            env:
+              OUTPUT_DIR: /export
+              SOURCE: mms
+              MODE: full
+              YEARS: &mmsBootstrapYears "2026,2025,2024,2023,2022,2021,2020,2019,2018,2017,2016,2015,2014,2013,2012,2011,2010,2009,2008,2007,2006,2005,2004,2003,2002,2001,2000"
+              MMS_CACHE_MODE: fetch-cache
+              MMS_CACHE_DIR: /export/mms-cache
+              CONCURRENT_REQUESTS: "5"
+              CONCURRENT_REQUESTS_PER_DOMAIN: "5"
+              http_proxy: *externalProxy
+              https_proxy: *externalProxy
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 250m
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+            securityContext: *containerSecurity
+      mms-bootstrap-replay:
+        type: cronjob
+        cronjob: *manualCronJob
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            command:
+              - /bin/bash
+              - -lc
+            args: *guardedReplay
+            env:
+              DATABASE_URL: *databaseUrl
+              OUTPUT_DIR: /export
+              SOURCE: mms
+              MODE: full
+              YEARS: *mmsBootstrapYears
+              MMS_CACHE_MODE: replay-cache
+              MMS_CACHE_DIR: /export/mms-cache
+              GDB_DISABLE_NETWORK_FETCHES: "true"
+              MMS_OFFLINE_REPLAY: "true"
+              USAG_BOOTSTRAP_MIN_RAINBOW_ROWS: "1000000"
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 500m
+                memory: 12Gi
+              limits:
+                memory: 24Gi
+            securityContext: *containerSecurity
+      usag:
+        type: cronjob
+        cronjob:
+          schedule: "0 12 * * 0"
+          timeZone: Australia/Sydney
+          suspend: true
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+          backoffLimit: 0
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            env:
+              DATABASE_URL: *databaseUrl
+              OUTPUT_DIR: /export
+              SOURCE: usag
+              MODE: incremental
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 250m
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+            securityContext: *containerSecurity
+      mso-fetch-cache:
+        type: cronjob
+        cronjob:
+          schedule: "0 18 * * 3"
+          timeZone: Australia/Sydney
+          suspend: true
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+          backoffLimit: 0
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            env:
+              OUTPUT_DIR: /export
+              SOURCE: mso
+              MODE: incremental
+              MSO_CACHE_MODE: fetch-cache
+              MSO_CACHE_DIR: /export/mso-cache
+              MSO_LOOKUP_CLUBS: "true"
+              CONCURRENT_REQUESTS: "5"
+              CONCURRENT_REQUESTS_PER_DOMAIN: "5"
+              http_proxy: *externalProxy
+              https_proxy: *externalProxy
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 250m
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+            securityContext: *containerSecurity
+      mso-replay-cache:
+        type: cronjob
+        cronjob:
+          schedule: "0 0 * * 4"
+          timeZone: Australia/Sydney
+          suspend: true
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+          backoffLimit: 0
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            command:
+              - /bin/bash
+              - -lc
+            args: *guardedReplay
+            env:
+              DATABASE_URL: *databaseUrl
+              OUTPUT_DIR: /export
+              SOURCE: mso
+              MODE: incremental
+              MSO_CACHE_MODE: replay-cache
+              MSO_CACHE_DIR: /export/mso-cache
+              MSO_LOOKUP_CLUBS: "true"
+              GDB_DISABLE_NETWORK_FETCHES: "true"
+              MSO_OFFLINE_REPLAY: "true"
+              USAG_BOOTSTRAP_MIN_RAINBOW_ROWS: "1000000"
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 250m
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+            securityContext: *containerSecurity
+      mms-fetch-cache:
+        type: cronjob
+        cronjob:
+          schedule: "0 6 * * 1"
+          timeZone: Australia/Sydney
+          suspend: true
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+          backoffLimit: 0
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            env:
+              OUTPUT_DIR: /export
+              SOURCE: mms
+              MODE: incremental
+              MMS_CACHE_MODE: fetch-cache
+              MMS_CACHE_DIR: /export/mms-cache
+              CONCURRENT_REQUESTS: "5"
+              CONCURRENT_REQUESTS_PER_DOMAIN: "5"
+              http_proxy: *externalProxy
+              https_proxy: *externalProxy
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 250m
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+            securityContext: *containerSecurity
+      mms-replay-cache:
+        type: cronjob
+        cronjob:
+          schedule: "0 12 * * 1"
+          timeZone: Australia/Sydney
+          suspend: true
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+          backoffLimit: 0
+        pod: *scraperPod
+        containers:
+          scraper:
+            image: *image
+            command:
+              - /bin/bash
+              - -lc
+            args: *guardedReplay
+            env:
+              DATABASE_URL: *databaseUrl
+              OUTPUT_DIR: /export
+              SOURCE: mms
+              MODE: incremental
+              MMS_CACHE_MODE: replay-cache
+              MMS_CACHE_DIR: /export/mms-cache
+              GDB_DISABLE_NETWORK_FETCHES: "true"
+              MMS_OFFLINE_REPLAY: "true"
+              USAG_BOOTSTRAP_MIN_RAINBOW_ROWS: "1000000"
+            probes: *disabledProbes
+            resources:
+              requests:
+                cpu: 250m
+                memory: 3Gi
+              limits:
+                memory: 4Gi
+            securityContext: *containerSecurity
+    persistence:
+      export:
+        existingClaim: gdb-scraper
+        globalMounts:
+          - path: /export
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/gdb/gdb/scraper/kustomization.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./pvc.yaml
+  - ./r2-backup.yaml

--- a/kubernetes/apps/gdb/gdb/scraper/pvc.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gdb-scraper
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: ceph-filesystem

--- a/kubernetes/apps/gdb/gdb/scraper/r2-backup.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/r2-backup.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: gdb-scraper-r2
+spec:
+  paused: true
+  sourcePVC: gdb-scraper
+  trigger:
+    schedule: "30 3 * * *"
+  restic:
+    copyMethod: Snapshot
+    pruneIntervalDays: 7
+    repository: gdb-scraper-volsync-r2-secret
+    volumeSnapshotClassName: csi-ceph-filesystem
+    cacheCapacity: 8Gi
+    cacheStorageClassName: openebs-hostpath
+    cacheAccessModes:
+      - ReadWriteOnce
+    storageClassName: ceph-filesystem
+    accessModes:
+      - ReadWriteMany
+    moverSecurityContext:
+      runAsUser: 568
+      runAsGroup: 568
+      fsGroup: 568
+      fsGroupChangePolicy: OnRootMismatch
+    retain:
+      daily: 7
+      weekly: 4
+      monthly: 2

--- a/kubernetes/apps/gdb/kustomization.yaml
+++ b/kubernetes/apps/gdb/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gdb
+components:
+  - ../../components/common
+resources:
+  - ./gdb/ks.yaml


### PR DESCRIPTION
## Summary
- restore the `gdb` namespace with a fresh two-instance 80Gi CNPG/PostGIS cluster and Barman/Garage backups
- run the corrected gdb-web 1.10.58 schema and static city seed through an automatic migration Job
- add a 50Gi RWX CephFS scraper cache with an initially paused R2 backup
- restore digest-pinned gdb-scraper 0.1.83 bootstrap, Scrape.do canary, and weekly fetch/replay CronJobs
- keep all twelve scraper CronJobs suspended until the database, backup, and provider canaries are validated

## Safety
- PostgreSQL is cluster-only; the historical LoadBalancer is not restored
- the old Barman catalog was empty, so this intentionally uses fresh `initdb` and a new `gdb-postgres-v2` backup server name
- fetch jobs receive proxy credentials but no database URL
- replay jobs receive the database URL and offline guards but no proxy credentials
- USAG-first replay guards require at least one million rainbow-table rows

## Validation
- all schema-backed YAML passed `check-jsonschema`
- all four GDB Kustomize trees build
- server-side dry-run admission passed for database, migration, and scraper resources
- full `flux-local test --all-namespaces --enable-helm`: 213 passed
- migration renders as one automatic Job using gdb-web 1.10.58
- scraper renders as 12 suspended CronJobs with expected schedules and secret separation
