### PR TITLE
fix(gdb): escape scraper shell variables

### DIFF
--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -151,7 +151,7 @@ spec:
                 min_rows="${USAG_BOOTSTRAP_MIN_RAINBOW_ROWS:-1000000}"
                 rainbow_rows="$(psql "$DATABASE_URL" -Atc "SELECT count(*) FROM usagnum_hash_lookup" | tr -d '[:space:]')"
                 if [ "${rainbow_rows:-0}" -lt "$min_rows" ]; then
-                  echo "USAG bootstrap preflight failed: rainbow table has ${rainbow_rows:-0} rows; need at least ${min_rows}."
+                  echo "USAG bootstrap preflight failed: rainbow table has $${rainbow_rows:-0} rows; need at least $${min_rows}."
                   exit 1
                 fi
                 exec /app/entrypoint.sh "$SOURCE"


### PR DESCRIPTION
## Summary
- escape runtime shell variables in the scraper USAG bootstrap guard
- prevent Flux strict post-build substitution from treating `min_rows` and `rainbow_rows` as cluster variables

## Validation
- live `flux build kustomization gdb-scraper --strict-substitute` succeeds
- generated command retains the intended `${rainbow_rows:-0}` and `${min_rows}` shell expansions
- app-template schema and Kustomize build pass
