### PR TITLE
fix(gdb): update scraper and cache backup

### DIFF
--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           scraper:
             image: &image
               repository: ghcr.io/adampetrovic/gdb-scraper
-              tag: 0.1.83@sha256:33c11ce1547820692c1617c4d50c45274b9d13abd327b17c48a124586458d94b
+              tag: 0.1.84@sha256:8c71e8b2611d5f64ec1f2329e19c687ff47bfba7a2a0ada1c15d0c7b57caff5d
             env:
               DATABASE_URL: &databaseUrl
                 valueFrom:

--- a/kubernetes/apps/gdb/gdb/scraper/r2-backup.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/r2-backup.yaml
@@ -10,17 +10,13 @@ spec:
   trigger:
     schedule: "30 3 * * *"
   restic:
-    copyMethod: Snapshot
+    copyMethod: Direct
     pruneIntervalDays: 7
     repository: gdb-scraper-volsync-r2-secret
-    volumeSnapshotClassName: csi-ceph-filesystem
     cacheCapacity: 8Gi
     cacheStorageClassName: openebs-hostpath
     cacheAccessModes:
       - ReadWriteOnce
-    storageClassName: ceph-filesystem
-    accessModes:
-      - ReadWriteMany
     moverSecurityContext:
       runAsUser: 568
       runAsGroup: 568


### PR DESCRIPTION
## Summary
- update GDB scraper to `0.1.84`, which supports MyMeetScores' live `meetmms.pl` route
- switch the RWX cache's Restic replication from Snapshot to Direct mode

## Why
The deployment canary exposed two live issues:
1. MyMeetScores changed its route from `meet.pl` to `meetmms.pl`; scraper PR adampetrovic/gdb-scraper#8 fixes this and its release passed all 154 tests.
2. VolSync Snapshot mode reported success but saw an empty directory. A Direct-mode canary backed up all seven files (350 KiB), creating R2 snapshot `2b397ec2` successfully.

## Validation
- gdb-scraper v0.1.84 CI/CD completed successfully
- app-template and ReplicationSource schemas pass
- strict Flux post-build substitution passes
- all 12 scraper CronJobs remain suspended
- server-side ReplicationSource admission dry-run passes
