### PR TITLE
fix(unpackerr): pin executable image

### DIFF
--- a/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
           app:
             image:
               repository: mirror.gcr.io/golift/unpackerr
-              tag: unstable@sha256:c9184266c35b4d337ef33f8c247ec8cc580f1fb461de18bd8b462ae44a1b0f5d
+              tag: 0.15.2@sha256:057e34740d26c34d81ec8e2faf8ec11f8dbfc77489b7a42826f52b37e5ee1b6c
             envFrom:
               - secretRef:
                   name: unpackerr-secret


### PR DESCRIPTION
## Summary
- pin Unpackerr to the verified executable `0.15.2` image
- recover from the broken `unstable` image merged in #3275, which ships `/unpackerr` as mode `0644`
- retain an immutable multi-architecture digest pin

## Why
The rollout of #3275 left Unpackerr unable to start with `exec: "/unpackerr": permission denied`. Upstream tracks this as Unpackerr/unpackerr#675. The fix has been merged upstream, but the affected tags have not been rebuilt. The selected 0.15.2 image was verified to contain `/unpackerr` with mode `0755`.

## Validation
- `mise x uv@0.12.3 -- uvx check-jsonschema --schemafile https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json kubernetes/apps/media/unpackerr/app/helmrelease.yaml`
- `kustomize build kubernetes/apps/media/unpackerr/app`
- inspected the linux/amd64 image filesystem and verified `/unpackerr` mode is `0755`
