### PR TITLE
feat(paperless): add Brother SMB scan inbox sidecar

### DIFF
--- a/kubernetes/apps/default/paperless-ngx/README.md
+++ b/kubernetes/apps/default/paperless-ngx/README.md
@@ -1,0 +1,195 @@
+# Paperless direct scanner inbox
+
+The Brother MFC-L2750DW (`10.0.40.7`) writes PDFs to
+`\\10.0.88.15\consume` using the dedicated `scanner` account. Samba runs beside
+Paperless in the **same pod** and both containers mount the root of a dedicated
+RWO Ceph-block inbox PVC.
+
+## Storage and security boundaries
+
+- Paperless keeps `/data/media`, `/data/data` and `/data/export` unchanged on PVC
+  `paperless-ngx`. Consumption moves from `/data/consume` to `/data/scan-inbox`,
+  which is the root of a separate 5Gi `paperless-ngx-scan-inbox` PVC.
+- Samba mounts **only** that dedicated PVC at `/scan-inbox`. Its `/data` is a
+  separate, size-limited `emptyDir` for Samba databases/cache. It cannot browse
+  the document library, exports, or Paperless application data.
+- There is no custom init container or `subPath` dependency. Kubelet applies pod
+  `fsGroup: 100` with `OnRootMismatch` so a newly provisioned volume root is
+  group-writable. Samba's Unix account matches Paperless's existing
+  `USERMAP_UID=568` / `USERMAP_GID=100`; uploaded files use `0660`.
+- The workload has one replica and uses `Recreate` (brief UI/scanning downtime
+  during upgrades). The existing HTTP Service name and Authelia route remain.
+- The old NAS mount was already removed from Paperless, Gotenberg and Tika on
+  `main`; this change does not reintroduce it. No NAS source data is copied,
+  removed or migrated. VolSync configuration for the primary Paperless claim is
+  unchanged: the primary backup target still uses NAS, with R2 secondary. The
+  transient inbox PVC is retained by Helm but is not included in those backups;
+  documents become protected after Paperless consumes them into its primary PVC.
+- SMB2/3 only; NTLMv2 only; no guests, SMB1, NTLMv1, NetBIOS/139, discovery,
+  host networking, recycling, wide links or followed symlinks. No public route.
+  SMB encryption/signing negotiation uses Samba defaults; this is not a promise
+  of mandatory transport encryption on this trusted routed LAN path.
+- `paperless-ngx-scanner` exposes **TCP 445 only** at BGP VIP `10.0.88.15`.
+  This address was unused in repository allocations and live Services when added.
+  Current Cilium IPAM covers `10.0.88.0/24` and advertises all LoadBalancer IPs;
+  this is **not** the old Envoy-only BGP configuration in the UniFi notes.
+- `externalTrafficPolicy: Local` preserves the printer source address and restricts
+  BGP advertisement to ready local endpoints. NodePort allocation is disabled.
+  `loadBalancerSourceRanges`, a **Paperless-pod-only** NetworkPolicy and Samba's
+  host ACL all restrict SMB to `10.0.40.7`. Loopback is allowed in Samba for local
+  control; pod-local traffic shares a trust boundary with the other sidecars.
+- The NetworkPolicy preserves HTTP/80 ingress, does not restrict egress or touch
+  namespace-wide policies, and blocks remote access to internal Tika/Gotenberg
+  ports (Paperless uses localhost). Kubelet health traffic and loopback are not
+  blocked by this policy. Source IP ACLs are defence in depth, **not identity**:
+  a compromised printer or host spoofing its address still needs the SMB password.
+  Do not allow router/intermediary SNAT or widen ACLs to a node/router subnet to
+  make a broken connection work. Confirm the observed source during acceptance.
+
+### Image startup exception
+
+`ghcr.io/crazy-max/samba:4.23.8` is pinned by OCI index digest. Its release source
+is `crazy-max/docker-samba` tag `4.23.8-r0` (the container tag omits `-r0`).
+This image starts as root: `/init` creates accounts in `/etc`, writes
+`/etc/samba/smb.conf` and `/etc/services.d`, and replaces `/var/lib/samba` and
+`/var/cache/samba` with links into its own `/data`. An immutable root filesystem
+is **not compatible with its unmodified entrypoint**. We explicitly retain a
+writable container root rather than masking the entire `/etc` with an emptyDir
+or replacing upstream startup code.
+
+The container drops all capabilities, then adds only account/file ownership,
+UID/GID switching, chroot, low-port bind and process termination capabilities
+(`CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`, `SYS_CHROOT`,
+`NET_BIND_SERVICE`, `KILL`). No privileged mode, `SYS_ADMIN`, `NET_ADMIN`, or
+`NET_RAW`; privilege escalation is disabled and seccomp uses `RuntimeDefault`.
+`smbd` switches to `scanner` for share I/O. Treat a root sidecar as part of the
+Paperless pod's trust boundary, not as a sandbox for hostile code.
+
+Startup/readiness/liveness use `smbcontrol smbd ping`, which checks the local
+Samba daemon. Upstream's anonymous `smbclient` healthcheck is unsuitable after
+turning off guest mapping. These checks do not prove an authenticated scanner
+upload works. Runtime startup with this reduced capability set must be verified
+before production acceptance; no container engine was available on the authoring
+machine to run that test.
+
+## Before merging / rollout prerequisites
+
+This change is **PR-only**. Do not merge until the secret exists and the firewall
+rule is ready. Do not manually apply the manifests to bypass Flux.
+
+1. **1Password:** in vault **`k8s`**, edit the existing item **`paperless`** and add
+   a top-level **concealed/password field** named exactly **`SCANNER_PASSWORD`**.
+   Generate a unique 24-character alphanumeric password in 1Password (one line,
+   no spaces/newlines; comfortably within common Brother firmware limits).
+   Reference: `op://k8s/paperless/SCANNER_PASSWORD`.
+   No username field or new item is needed; the SMB username is fixed as `scanner`.
+   Do not reuse or change `ADMIN_PASS`, the NAS password or database credentials.
+   ExternalSecret `paperless-scanner` creates `paperless-scanner-secret` with key
+   `password`; it is mounted read-only, mode `0400`, only into Samba. Neither a
+   plaintext password nor a real credential was generated/retrieved for this PR.
+2. **UniFi UI, manual:** add an Allow rule named `printer-to-paperless-smb`:
+   source zone **Cameras**, source IP **`10.0.40.7/32`**; destination zone
+   **Internal**, destination IP **`10.0.88.15/32`**; **TCP destination port 445**;
+   enable **Auto Allow Return Traffic**. Put it before the Cameras → Internal
+   catch-all block. Ensure the routed `10.0.88.0/24` network is in Internal and
+   that inter-VLAN traffic is not source-NATed. No 139/UDP/discovery or subnet-wide
+   allow is required. This PR does not change the gateway.
+3. Confirm printer DHCP reservation/address, unused VIP `10.0.88.15`, the current
+   UCG BGP policy, healthy recent backups and capacity for the new 5Gi inbox PVC.
+   An unavailable consumer can fill the inbox and block further scans without
+   filling the primary Paperless claim.
+4. Ensure no scan is in progress; review and merge separately when ready. Flux
+   will recreate the pod. If the scanner secret is missing, the new pod cannot
+   start, causing Paperless downtime. Check ExternalSecret Ready, inbox PVC Bound,
+   Samba logs, pod readiness, Service endpoint and BGP next-hop before configuring
+   the printer. Do not print the secret or dump all container environment values.
+
+## Brother setup and acceptance
+
+In Brother Web Based Management, create a **Scan to Network / CIFS** profile
+(menu wording varies by firmware):
+
+| Setting | Value |
+|---|---|
+| Profile name | Paperless |
+| Network folder path | `\\10.0.88.15\consume` |
+| Username | `scanner` (if a domain is required, `WORKGROUP\scanner`) |
+| Password | Value of `k8s / paperless / SCANNER_PASSWORD` |
+| Authentication | NTLMv2, or Auto if that is the only supported setting |
+| Port, if shown | TCP 445 |
+| File type | PDF (multi-page where desired); avoid encrypted/password PDF |
+| File name | Unique date/time or sequential suffix for **every** scan |
+| Resolution | 300 dpi to start |
+
+Brother's listed CIFS capability does **not** prove the installed firmware's SMB
+dialect. Run the profile connection test and scan a harmless single-page PDF,
+then a slow/multi-page duplex job. Confirm the complete page count in Paperless,
+correct `568:100` file ownership, and removal from the inbox after consumption.
+If SMB negotiation/authentication fails, check firmware/profile/logs; **do not**
+downgrade to SMB1/NTLMv1 or allow guests. Stop and reassess compatibility instead.
+
+Also verify HTTP/Authelia still works and TCP 445/authenticated share access is
+rejected from a non-printer host. Validate the actual source with packet capture
+or Cilium observability (must be `10.0.40.7`, not a node or gateway IP). The Samba
+pod should be the sole ready endpoint and UCG's next-hop should be that node.
+The narrow UniFi firewall rule has been added and verified; no live deployment or
+printer upload was performed while preparing this PR.
+
+## Completion, retries and recovery
+
+Paperless **3.1.3** supports `PAPERLESS_CONSUMER_POLLING_INTERVAL=10` and
+`PAPERLESS_CONSUMER_STABILITY_DELAY=120`: during normal watching, a file must have
+unchanged size and mtime for 120 seconds before consumption. This increases the
+five-second stability default for scanner uploads; expect a few minutes' delay.
+Do not use the removed Paperless 2.x polling/retry variables.
+
+A stability delay is **not an SMB close/atomic-commit guarantee**. A scanner
+pausing longer than 120 seconds mid-file, or an interrupted upload left in the
+inbox, can still look stable. Additionally, Paperless 3.1.3's startup scan queues
+existing files immediately, before the stability watcher starts: a consumer
+restart during an upload can bypass the delay. Stop scanning before planned
+restarts and inspect interrupted jobs after crashes. Test the longest real job
+before relying on direct scanning; increase the delay if appropriate. If the printer writes under a
+fixed final filename for arbitrarily long pauses, this design cannot guarantee
+completion without a separate staging/commit mechanism and should not be accepted
+for unattended use. No custom ingestion daemon is introduced by this change.
+
+- Always use unique filenames. Reusing a name can overwrite a still-pending scan;
+  content duplicate detection does not prevent filename collisions.
+- The existing `PAPERLESS_CONSUMER_DELETE_DUPLICATES=true` is retained: a successful
+  duplicate detection removes the inbox copy, not the existing library document.
+- A container/pod restart or node reschedule preserves pending scans on the
+  dedicated Ceph PVC, but interrupts active SMB transfers. The inbox is not part
+  of the primary Paperless VolSync restore, so a full cluster rebuild can lose
+  unconsumed scans. Samba credentials/runtime are recreated from the Secret.
+  Review Paperless task failures, verify failed PDFs are complete, then rescan
+  with a **new filename**. Do not blindly delete inbox contents or assume every
+  failed upload is retried automatically.
+- Inspect suspect/partial files before moving them out of the inbox for manual
+  recovery; do not change library ownership or copy the old NAS inbox wholesale.
+- Password rotation: update the 1Password field, wait for ExternalSecret refresh
+  and Reloader to restart the pod (Samba loads passwords at startup), then update
+  the printer. Avoid rotation during a scan.
+- Rollback: stop new scans first and inventory pending `/data/scan-inbox` files.
+  Reverting this change restores `/data/consume` on the primary PVC but **does not
+  delete or consume** the retained inbox PVC; recover those files deliberately.
+  Do not delete/recreate either PVC or the NAS source. Helm failure rollback has
+  the same caveat.
+
+## Validation and sources
+
+Validated without deploying: app Kustomize build; Helm lint and render against
+repository-pinned **app-template 5.1.0** (not the older v4 assumption); JSON schemas
+for HelmRelease, ExternalSecret, Kustomization and NetworkPolicy; rendered core
+resource schemas and targeted assertions for mounts, selectors, Service/route
+names, source filters and secret isolation. Container startup, `testparm`, reduced
+capabilities, SMB authentication and physical Brother compatibility remain runtime
+acceptance checks because the local Docker daemon is unavailable.
+
+Sources:
+- [Pinned Samba release README](https://github.com/crazy-max/docker-samba/blob/4.23.8-r0/README.md)
+- [Samba account/config startup](https://github.com/crazy-max/docker-samba/blob/4.23.8-r0/rootfs/etc/cont-init.d/01-config.sh)
+- [Samba Dockerfile](https://github.com/crazy-max/docker-samba/blob/4.23.8-r0/Dockerfile)
+- [Upstream healthcheck](https://github.com/crazy-max/docker-samba/blob/4.23.8-r0/rootfs/usr/local/bin/healthcheck)
+- [Paperless 3.1.3 consumer configuration](https://github.com/paperless-ngx/paperless-ngx/blob/v3.1.3/docs/configuration.md#PAPERLESS_CONSUMER_STABILITY_DELAY)
+- [Paperless 3.1.3 stability implementation](https://github.com/paperless-ngx/paperless-ngx/blob/v3.1.3/src/documents/management/commands/document_consumer.py)

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -17,8 +17,14 @@ spec:
       retries: 3
       strategy: rollback
   values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
       paperless-ngx:
+        replicas: 1
+        strategy: Recreate
         annotations:
           reloader.stakater.com/auto: 'true'
         initContainers:
@@ -30,6 +36,61 @@ spec:
               - secretRef:
                   name: paperless-secret
         containers:
+          samba:
+            image:
+              repository: ghcr.io/crazy-max/samba
+              tag: 4.23.8@sha256:b37f7af97c773eddb593537f64da6389e5ee6695bcecf44f3ba1a8a6bcf34125
+            env:
+              TZ: "${TZ}"
+              CONFIG_FILE: /config/config.yml
+              SAMBA_WORKGROUP: WORKGROUP
+              SAMBA_SERVER_STRING: Paperless scan inbox
+              SAMBA_FOLLOW_SYMLINKS: "no"
+              SAMBA_WIDE_LINKS: "no"
+              SAMBA_HOSTS_ALLOW: "127.0.0.1 10.0.40.7"
+              AVAHI_ENABLE: "0"
+              WSDD2_ENABLE: "0"
+            securityContext:
+              # Upstream /init creates Unix accounts, /etc/samba and /etc/services.d,
+              # and rewrites /var/{lib,cache}/samba. smbd drops to scanner for I/O.
+              runAsUser: 0
+              runAsGroup: 0
+              runAsNonRoot: false
+              readOnlyRootFilesystem: false
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: [ALL]
+                add: [CHOWN, DAC_OVERRIDE, FOWNER, KILL, SETGID, SETUID, SYS_CHROOT, NET_BIND_SERVICE]
+              seccompProfile:
+                type: RuntimeDefault
+            probes:
+              # The image's anonymous smbclient healthcheck assumes guest mapping;
+              # use the local daemon control channel with map-to-guest disabled.
+              readiness: &sambaProbe
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: [smbcontrol, smbd, ping]
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              liveness: *sambaProbe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: [smbcontrol, smbd, ping]
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 20m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
           gotenburg:
             image:
               repository: mirror.gcr.io/thecodingmachine/gotenberg
@@ -59,11 +120,14 @@ spec:
               PAPERLESS_ALLOWED_HOSTS: paperless.${SECRET_DOMAIN},paperless-ngx.default.svc.cluster.local
               PAPERLESS_ENABLE_HTTP_REMOTE_USER: 'true'
               PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME: HTTP_REMOTE_USER
-              PAPERLESS_CONSUMPTION_DIR: /data/consume
+              PAPERLESS_CONSUMPTION_DIR: /data/scan-inbox
               PAPERLESS_DATA_DIR: /data/data
               PAPERLESS_MEDIA_ROOT: /data/media
               PAPERLESS_EXPORT_DIR: /data/export
-              PAPERLESS_CONSUMER_POLLING_INTERVAL: 60
+              PAPERLESS_CONSUMER_POLLING_INTERVAL: 10
+              # Paperless 3.x: unchanged size + mtime for 120s before consumption.
+              # This is a heuristic, not an SMB close/commit guarantee; see README.
+              PAPERLESS_CONSUMER_STABILITY_DELAY: 120
               PAPERLESS_CONSUMER_IGNORE_PATTERNS: '["^\\.DS_Store$", "^\\._.*"]'
               PAPERLESS_CONSUMER_IGNORE_DIRS: '["^\\.stfolder$", "^@eaDir$"]'
               PAPERLESS_TRUSTED_PROXIES: 10.69.0.0/16
@@ -81,7 +145,21 @@ spec:
               limits:
                 memory: 6Gi
     service:
+      scanner:
+        controller: paperless-ngx
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: 10.0.88.15
+        externalTrafficPolicy: Local
+        loadBalancerSourceRanges:
+          - 10.0.40.7/32
+        allocateLoadBalancerNodePorts: false
+        ports:
+          smb:
+            port: 445
       app:
+        # Keep the existing service name when adding a second Service.
+        forceRename: *app
         controller: paperless-ngx
         ports:
           http:
@@ -93,6 +171,10 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
     persistence:
       config:
         enabled: true
@@ -101,6 +183,43 @@ spec:
           paperless-ngx:
             app:
               - path: /data
+      scan-inbox:
+        type: persistentVolumeClaim
+        forceRename: paperless-ngx-scan-inbox
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: ceph-block
+        retain: true
+        advancedMounts:
+          paperless-ngx:
+            app:
+              - path: /data/scan-inbox
+            samba:
+              - path: /scan-inbox
+      samba-runtime:
+        type: emptyDir
+        sizeLimit: 256Mi
+        advancedMounts:
+          paperless-ngx:
+            samba:
+              - path: /data
+      samba-config:
+        type: configMap
+        name: paperless-samba-config
+        advancedMounts:
+          paperless-ngx:
+            samba:
+              - path: /config
+                readOnly: true
+      samba-password:
+        type: secret
+        name: paperless-scanner-secret
+        defaultMode: 0400
+        advancedMounts:
+          paperless-ngx:
+            samba:
+              - path: /run/secrets/scanner
+                readOnly: true
       post-consume:
         enabled: true
         type: configMap

--- a/kubernetes/apps/default/paperless-ngx/app/kustomization.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/kustomization.yaml
@@ -4,9 +4,14 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./scanner-externalsecret.yaml
+  - ./scanner-networkpolicy.yaml
 components:
   - ../../../../components/authelia-proxy
 configMapGenerator:
+  - name: paperless-samba-config
+    files:
+      - config.yml=./resources/samba.yaml
   - name: paperless-post-consume
     files:
       - ./resources/post_consume.py

--- a/kubernetes/apps/default/paperless-ngx/app/resources/samba.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/resources/samba.yaml
@@ -1,0 +1,35 @@
+---
+auth:
+  - user: scanner
+    group: users
+    uid: 568
+    gid: 100
+    password_file: /run/secrets/scanner/password
+global:
+  - "server min protocol = SMB2_02"
+  - "server max protocol = SMB3"
+  - "ntlm auth = ntlmv2-only"
+  - "map to guest = Never"
+  - "usershare allow guests = no"
+  - "hosts deny = ALL"
+  - "load printers = no"
+  - "restrict anonymous = 2"
+  - "server multi channel support = no"
+share:
+  - name: consume
+    path: /scan-inbox
+    browsable: "no"
+    readonly: "no"
+    guestok: "no"
+    validusers: scanner
+    writelist: scanner
+    recycle: "no"
+    options:
+      # Do not inherit upstream's macOS/Time Machine VFS modules.
+      - "vfs objects ="
+      - "create mask = 0660"
+      - "force create mode = 0660"
+      - "directory mask = 0770"
+      - "force directory mode = 0770"
+      - "follow symlinks = no"
+      - "wide links = no"

--- a/kubernetes/apps/default/paperless-ngx/app/scanner-externalsecret.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/scanner-externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: paperless-scanner
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: paperless-scanner-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        password: "{{ .SCANNER_PASSWORD }}"
+  data:
+    - secretKey: SCANNER_PASSWORD
+      remoteRef:
+        key: paperless
+        property: SCANNER_PASSWORD

--- a/kubernetes/apps/default/paperless-ngx/app/scanner-networkpolicy.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/scanner-networkpolicy.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0-standalone-strict/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: paperless-scanner
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: paperless-ngx
+      app.kubernetes.io/instance: paperless-ngx
+      app.kubernetes.io/controller: paperless-ngx
+  policyTypes:
+    - Ingress
+  ingress:
+    # Preserve Paperless HTTP access (Envoy, API clients and health checks).
+    # No namespace-wide policy or egress restriction is introduced.
+    - ports:
+        - protocol: TCP
+          port: 80
+    - from:
+        - ipBlock:
+            cidr: 10.0.40.7/32
+      ports:
+        - protocol: TCP
+          port: 445


### PR DESCRIPTION
## Summary

Add a dedicated Samba sidecar for Brother MFC-L2750DW scan-to-network.

- Expose `\\10.0.88.15\consume` to the fixed `scanner` account on TCP 445 only.
- Dynamically provision a retained 5Gi `paperless-ngx-scan-inbox` Ceph PVC and mount its root into both Paperless and Samba.
- Use no custom init container and no `subPath`; `fsGroup: 100` makes a fresh volume root writable to the existing `568:100` application identity.
- Keep the primary Paperless PVC isolated from Samba. Move consumption from `/data/consume` to the dedicated volume at `/data/scan-inbox`.
- Set one replica explicitly and use `Recreate`, restoring the currently scaled-to-zero Paperless deployment while avoiding concurrent RWO PVC attachment.
- Enforce SMB2/3 and NTLMv2 with no guests, discovery, SMB1, NTLMv1, symlink following, recycling, host networking, or data NodePort.
- Restrict access to printer `10.0.40.7` with the UniFi firewall, LoadBalancer source range, NetworkPolicy, and Samba host ACL.

## Rollout prerequisites completed

Verified on 8 September 2026 AEST:

- Created a unique concealed 24-character `SCANNER_PASSWORD` field in existing 1Password item `k8s/paperless`; no secret value entered Git or logs.
- Added and live-verified UniFi rule `Printer → Paperless (SMB)`: Cameras → Internal, `10.0.40.7` → `10.0.88.15`, TCP/445 only, automatic return traffic enabled, before catch-all drop.
- Confirmed `10.0.88.15` is unused by live LoadBalancer Services.
- Confirmed Cilium advertises all LoadBalancer VIPs and UCG currently receives the existing service routes over established BGP sessions.
- Confirmed the latest primary Paperless VolSync snapshot completed successfully.

## Storage and runtime caveats

- The inbox PVC is retained by Helm but is not part of the primary Paperless VolSync backup. Pod restarts and node rescheduling preserve pending scans; a full cluster rebuild can lose unconsumed scans.
- Upstream Samba `/init` requires root and a writable root filesystem for its own account/runtime setup. There is no additional custom init container.
- `smbcontrol smbd ping` probes daemon health but is not an authenticated upload test.
- Paperless's 120-second stability delay mitigates ordinary partial uploads but is not an atomic SMB-close guarantee. Test a slow multi-page scan and avoid scans during pod restarts.

## Validation

Passed after the no-init refactor:

- `kustomize build kubernetes/apps/default/paperless-ngx/app`
- app-template 5.1.0 `helm lint` and `helm template`
- HelmRelease, ExternalSecret, NetworkPolicy, and Kustomization JSON schemas
- Rendered retained `paperless-ngx-scan-inbox` PVC: Ceph RWO, 5Gi
- Rendered only the existing `01-init-db` init container
- Rendered both inbox mounts at volume root with no `subPath`
- Targeted SMB2/3 and NTLMv2 hardening assertions

Runtime acceptance after merge: ExternalSecret readiness, PVC binding, pod/Samba health, VIP/BGP route, authenticated test upload, Paperless ingestion, and rejection from a non-printer source.
