### PR TITLE
feat(observability): monitor UNAS storage

### DIFF
--- a/kubernetes/apps/observability/unpoller/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/unpoller/app/externalsecret.yaml
@@ -16,6 +16,8 @@ spec:
       data:
         UP_UNIFI_DEFAULT_USER: "{{ .USERNAME }}"
         UP_UNIFI_DEFAULT_PASS: "{{ .PASSWORD }}"
+        UP_UNAS_DEVICE_0_USER: "{{ .UNAS_USERNAME }}"
+        UP_UNAS_DEVICE_0_PASS: "{{ .UNAS_PASSWORD }}"
   dataFrom:
     - extract:
         key: unifi-poller

--- a/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
@@ -41,6 +41,10 @@ spec:
               UP_UNIFI_DEFAULT_VERIFY_SSL: true
               UP_UNIFI_DEFAULT_SAVE_SITES: true
               UP_UNIFI_DEFAULT_SAVE_DPI: true
+              UP_UNAS_ENABLE: true
+              UP_UNAS_DEVICE_0_URL: https://${SECRET_UNAS_IP}
+              UP_UNAS_DEVICE_0_VERIFY_SSL: false
+              UP_UNAS_DEVICE_0_TIMEOUT: 60s
               UP_INFLUXDB_DISABLE: true
               UP_PROMETHEUS_DISABLE: false
               UP_PROMETHEUS_NAMESPACE: unpoller

--- a/kubernetes/components/common/vars/cluster-secrets.sops.yaml
+++ b/kubernetes/components/common/vars/cluster-secrets.sops.yaml
@@ -14,11 +14,11 @@ stringData:
     SECRET_NFS_IP: ENC[AES256_GCM,data:clcHJFThL+T0,iv:64TQveQHmFeGKyjIkNISsjamaWz05vI9A1iO0pHQ1qo=,tag:+31u4rWDr9JfRMF3aunY6g==,type:str]
     SECRET_SIGENERGY_IP: ENC[AES256_GCM,data:btA4jgOddu9zmw==,iv:N1LXn1TOEXiIqLQhVVtHSfdm0RNnwGqUlpN/mw69Qng=,tag:e9kelMvWEo4neA4ABpBQUA==,type:str]
     TZ: ENC[AES256_GCM,data:WE0+y+BvfM1feLWrqXXkGA==,iv:sAiBEf2XlqPNE5irq7/vKCbiwRqezIq0+8W08z3sLJw=,tag:CnnZTl+3Ry/x7Mhfne7tqg==,type:str]
+    SECRET_UNAS_IP: ENC[AES256_GCM,data:HUcVJ+HEL9rTSg==,iv:eHlU0nitIx7ub9Q99HlCprTs3tG+NCA0oyKGQqOvDrw=,tag:EUqumZELDLjslxQZSxYpdA==,type:str]
 # noinspection KubernetesUnknownKeys
 sops:
     age:
-        - recipient: age1pvlc4c05yg9g0pst6f6uvthh7942vt5tx79ycva92y8matj2ne5qvz4md5
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFb0FKbWZva1BPZTNBZS93
             L09hNWU5TWFFWEV1NkkvZ2R6OS9Nanp4TGtZCkhCKy9FKytoSTE2UEFLaS84cDRw
@@ -26,7 +26,8 @@ sops:
             Z1FvYjVhYnFnY3V0Y3NDbmpsaHZjOTgKAdPthVGTjniTw4pmiGPnHrbJ376UrxBj
             4BB9t5POvirLSsszEUTlZ44zKeOzSACmbqYqphyaO/Znpnb3Z5JKug==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-08T09:09:35Z"
-    mac: ENC[AES256_GCM,data:FzZ6o06+ov7FYycnDlRBFTNX5m9G+K3n2py0OmOFwPdfnOIdirPvreC8SD4t8OjI9tjcB8A94cJBehUGwBrrpHB4rFf9NGlzaoMfrydXjCLZu/e/Gzu5gja24v3ZIfCEt1XdFReTCWVe/YVOTWbfFTTUh6o5mzPP0+IjbLJ/jSY=,iv:yhzUXagv8dsN+VBiztIsSm6uPnov/or1okBW6FpIpx0=,tag:eUw04E3eHwcI5HwdOv1bNw==,type:str]
+          recipient: age1pvlc4c05yg9g0pst6f6uvthh7942vt5tx79ycva92y8matj2ne5qvz4md5
     encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-09-07T01:52:33Z"
+    mac: ENC[AES256_GCM,data:sQLlQ6c5CxIGR8HSPYM/7ddhp5Phi7sZVlaM7g170pKlr+NkhXOezPaoKc/NmleoFiWInVz/rSMWCLUMJgyPq1ZiA3l7zml9FOfcpq53aXGvg/xAhsiaI1cuCiBlxz+72XzDa2fr8cRpd9l6T6S+owxDBdLZUwYQaDquu4MtHww=,iv:HnrrPTIRVL0g5o7GzIy9wtXxYf3VXR30nnsMNnPfDew=,tag:9Gyn3ltjDvxf3rbydidPaQ==,type:str]
     version: 3.11.0


### PR DESCRIPTION
## Summary
- add the UNAS Pro 8 address to encrypted cluster substitutions
- enable unpoller's opt-in UNAS input with device-specific credentials from 1Password
- poll the local UNAS API over HTTPS with certificate verification disabled for its appliance certificate

## Validation
- app-template HelmRelease schema validation
- ExternalSecret CRD schema validation
- decrypted cluster Secret client-side dry-run
- unpoller app Kustomize render
- authenticated all four UNAS API endpoints with the configured 1Password credentials (HTTP 200)
