### PR TITLE
chore(repo): ignore Pi subagent schedules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ Brewfile.lock.json
 .claude
 # pi
 .kstack
+.pi/subagent-schedules/
 # wiki
 wiki


### PR DESCRIPTION
## Summary
- ignore machine-local Pi subagent schedule files
- keep tracked project skills and TODOs unchanged

## Validation
- confirmed the generated schedule remains on disk but no longer appears in `jj status`
