### PR TITLE
fix(storage): remove pre-cutover Synology mounts

### DIFF
--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -133,9 +133,8 @@ spec:
         globalMounts:
           - path: /dev/bus/usb
       media:
-        type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/k8s/frigate
+        type: emptyDir
+        sizeLimit: 100Gi
         globalMounts:
           - path: /media
 

--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -185,16 +185,6 @@ spec:
         globalMounts:
           - path: /config/.cache/uv
 
-      music:
-        type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/music
-        advancedMounts:
-          homeassistant:
-            app:
-              - path: /music
-                readOnly: true
-
       deploy-key:
         type: secret
         name: home-assistant-secret

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -59,7 +59,7 @@ spec:
               PAPERLESS_ALLOWED_HOSTS: paperless.${SECRET_DOMAIN},paperless-ngx.default.svc.cluster.local
               PAPERLESS_ENABLE_HTTP_REMOTE_USER: 'true'
               PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME: HTTP_REMOTE_USER
-              PAPERLESS_CONSUMPTION_DIR: /library/consume
+              PAPERLESS_CONSUMPTION_DIR: /data/consume
               PAPERLESS_DATA_DIR: /data/data
               PAPERLESS_MEDIA_ROOT: /data/media
               PAPERLESS_EXPORT_DIR: /data/export
@@ -101,12 +101,6 @@ spec:
           paperless-ngx:
             app:
               - path: /data
-      downloads:
-        type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/k8s/paperless
-        globalMounts:
-          - path: /library
       post-consume:
         enabled: true
         type: configMap


### PR DESCRIPTION
## Summary
- remove Home Assistant's read-only Synology music mount before the NAS cutover
- move Paperless consumption from the omitted Synology inbox to `/data/consume` on its retained PVC
- make Frigate recordings ephemeral with a 100 GiB `emptyDir`

## Why
These are the online pre-window changes needed to remove optional Synology dependencies. They allow Home Assistant and Frigate to remain online during final NAS quiescence, while preserving Paperless documents under `/data`.

## Validation
- app-template schema validation passed for all three HelmReleases
- `kustomize build` passed for all three application directories
- rendered manifests contain none of `/volume2/music`, `/volume2/k8s/paperless`, or `/volume2/k8s/frigate` for these workloads
