### PR TITLE
revert(storage): restore Synology mounts

### DIFF
--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -133,8 +133,9 @@ spec:
         globalMounts:
           - path: /dev/bus/usb
       media:
-        type: emptyDir
-        sizeLimit: 100Gi
+        type: nfs
+        server: ${SECRET_NFS_DOMAIN}
+        path: /volume2/k8s/frigate
         globalMounts:
           - path: /media
 

--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -185,6 +185,16 @@ spec:
         globalMounts:
           - path: /config/.cache/uv
 
+      music:
+        type: nfs
+        server: ${SECRET_NFS_DOMAIN}
+        path: /volume2/music
+        advancedMounts:
+          homeassistant:
+            app:
+              - path: /music
+                readOnly: true
+
       deploy-key:
         type: secret
         name: home-assistant-secret

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -59,7 +59,7 @@ spec:
               PAPERLESS_ALLOWED_HOSTS: paperless.${SECRET_DOMAIN},paperless-ngx.default.svc.cluster.local
               PAPERLESS_ENABLE_HTTP_REMOTE_USER: 'true'
               PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME: HTTP_REMOTE_USER
-              PAPERLESS_CONSUMPTION_DIR: /data/consume
+              PAPERLESS_CONSUMPTION_DIR: /library/consume
               PAPERLESS_DATA_DIR: /data/data
               PAPERLESS_MEDIA_ROOT: /data/media
               PAPERLESS_EXPORT_DIR: /data/export
@@ -101,6 +101,12 @@ spec:
           paperless-ngx:
             app:
               - path: /data
+      downloads:
+        type: nfs
+        server: ${SECRET_NFS_DOMAIN}
+        path: /volume2/k8s/paperless
+        globalMounts:
+          - path: /library
       post-consume:
         enabled: true
         type: configMap


### PR DESCRIPTION
## Incident
Home Assistant entered recovery mode immediately after PR #3333 removed `/music`.

The log reports:

```text
Invalid config for 'homeassistant' at configuration.yaml, line 12: not a directory for dictionary value 'media_dirs->music', got '/music'
Unable to set up core integrations. Activating recovery mode
```

## Recovery
Revert all storage changes from #3333 to the known-good pre-cutover state:
- restore Home Assistant `/volume2/music` at `/music`
- restore Paperless `/library` and `/library/consume`
- restore Frigate Synology recording storage

## Validation
- app-template schema validation passed for all three HelmReleases
- Home Assistant rendered manifest contains the `/music` NFS mount
