### PR TITLE
fix(storage): decouple optional Synology mounts safely

### DIFF
--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -133,9 +133,8 @@ spec:
         globalMounts:
           - path: /dev/bus/usb
       media:
-        type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/k8s/frigate
+        type: emptyDir
+        sizeLimit: 100Gi
         globalMounts:
           - path: /media
 

--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -186,9 +186,7 @@ spec:
           - path: /config/.cache/uv
 
       music:
-        type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/music
+        type: emptyDir
         advancedMounts:
           homeassistant:
             app:

--- a/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ngx/app/helmrelease.yaml
@@ -59,7 +59,7 @@ spec:
               PAPERLESS_ALLOWED_HOSTS: paperless.${SECRET_DOMAIN},paperless-ngx.default.svc.cluster.local
               PAPERLESS_ENABLE_HTTP_REMOTE_USER: 'true'
               PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME: HTTP_REMOTE_USER
-              PAPERLESS_CONSUMPTION_DIR: /library/consume
+              PAPERLESS_CONSUMPTION_DIR: /data/consume
               PAPERLESS_DATA_DIR: /data/data
               PAPERLESS_MEDIA_ROOT: /data/media
               PAPERLESS_EXPORT_DIR: /data/export
@@ -101,12 +101,6 @@ spec:
           paperless-ngx:
             app:
               - path: /data
-      downloads:
-        type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/k8s/paperless
-        globalMounts:
-          - path: /library
       post-consume:
         enabled: true
         type: configMap


### PR DESCRIPTION
## Summary
- replace Home Assistant's Synology music mount with an empty `/music` volume
- move Paperless consumption onto `/data/consume` on its retained PVC
- make Frigate recordings ephemeral with a 100 GiB `emptyDir`

## Incident correction
PR #3333 removed `/music` entirely, which made `homeassistant.media_dirs.music` invalid and activated recovery mode. PR #3334 restored the known-good mounts. This follow-up preserves the required `/music` directory while decoupling its source data.

## Validation
- app-template schemas pass for all three HelmReleases
- all three Kustomizations render
- Home Assistant render has `type: emptyDir` mounted read-only at `/music`
- Paperless and Frigate renders no longer reference their old Synology paths
