### PR TITLE
feat(storage): initialize fresh Kopia repository on UNAS

### DIFF
--- a/kubernetes/apps/network/external-dns/unifi/dnsendpoint.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/dnsendpoint.yaml
@@ -11,6 +11,9 @@ spec:
     - dnsName: "nas-direct.${SECRET_DOMAIN}"
       recordType: A
       targets: ["10.0.10.3"]
+    - dnsName: "unas-direct.${SECRET_DOMAIN}"
+      recordType: A
+      targets: ["10.0.10.95"]
     - dnsName: "nvr-direct.${SECRET_DOMAIN}"
       recordType: A
       targets: ["10.0.50.2"]

--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -19,6 +19,46 @@ spec:
       retries: 3
   values:
     controllers:
+      bootstrap-repository:
+        type: job
+        annotations:
+          helm.sh/hook: pre-install,pre-upgrade
+          helm.sh/hook-delete-policy: before-hook-creation
+          helm.sh/hook-weight: "-10"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/kopia
+              tag: 0.23.1@sha256:27da0a33b44e1b902150a6c963514237217464bb13118a95bb056667be93cda5
+            env:
+              KOPIA_LOG_DIR: /tmp/logs
+            envFrom:
+              - secretRef:
+                  name: kopia-secret
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                if [ -e /repository/kopia.repository.f ]; then
+                    echo "Kopia repository already exists"
+                    exit 0
+                fi
+                if find /repository -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+                    echo "Refusing to initialize non-empty Kopia share" >&2
+                    exit 1
+                fi
+                kopia repository create filesystem \
+                    --create-only \
+                    --path=/repository \
+                    --config-file=/tmp/repository.config \
+                    --cache-directory=/tmp/cache \
+                    --override-hostname=volsync.volsync-system.svc.cluster.local \
+                    --override-username=volsync
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
       kopia:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -100,13 +140,17 @@ spec:
             subPath: repository.config
       repository:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/kopia
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/kopia
         globalMounts:
           - path: /repository
       tmpfs:
         type: emptyDir
         advancedMounts:
+          bootstrap-repository:
+            app:
+              - path: /tmp
+                subPath: bootstrap
           kopia:
             app:
               - path: /config/cache

--- a/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
@@ -111,8 +111,8 @@ spec:
               value: Object.spec.template.spec.volumes{
                 name: "repository",
                 nfs: Object.spec.template.spec.volumes.nfs{
-                  server: "${SECRET_NFS_DOMAIN}",
-                  path: "/volume2/kopia"
+                  server: "unas-direct.${SECRET_DOMAIN}",
+                  path: "/var/nfs/shared/kopia"
                 }
               }
             }

--- a/kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml
@@ -44,8 +44,8 @@ spec:
               value: Object.spec.template.spec.volumes{
                 name: "repository",
                 nfs: Object.spec.template.spec.volumes.nfs{
-                  server: "${SECRET_NFS_DOMAIN}",
-                  path: "/volume2/kopia"
+                  server: "unas-direct.${SECRET_DOMAIN}",
+                  path: "/var/nfs/shared/kopia"
                 }
               }
             },


### PR DESCRIPTION
## Summary
- add `unas-direct` internal DNS for the UNAS Pro 8
- bootstrap a brand-new Kopia filesystem repository with a one-time Helm pre-upgrade Job
- point the Kopia server, VolSync movers, and maintenance jobs at the supported UNAS NFS share
- retain paused backup schedules until the new repository is verified

## Safety
- does not copy or adopt historical `staging3/kopia`
- refuses bootstrap when the UNAS share is non-empty without a valid Kopia repository marker
- bootstrap hook runs before the normal Kopia Deployment and is recreated safely on later upgrades

## Validation
- app-template HelmRelease JSON schema passed
- Kubernetes MutatingAdmissionPolicy JSON schemas passed
- all four changed Kustomizations rendered successfully
- server-side dry-run passed
