### PR TITLE
chore(volsync): resume backups on fresh UNAS repository

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -19,46 +19,6 @@ spec:
       retries: 3
   values:
     controllers:
-      bootstrap-repository:
-        type: job
-        annotations:
-          helm.sh/hook: pre-install,pre-upgrade
-          helm.sh/hook-delete-policy: before-hook-creation
-          helm.sh/hook-weight: "-10"
-        containers:
-          app:
-            image:
-              repository: ghcr.io/home-operations/kopia
-              tag: 0.23.1@sha256:27da0a33b44e1b902150a6c963514237217464bb13118a95bb056667be93cda5
-            env:
-              KOPIA_LOG_DIR: /tmp/logs
-            envFrom:
-              - secretRef:
-                  name: kopia-secret
-            command:
-              - /bin/sh
-              - -c
-              - |
-                set -eu
-                if [ -e /repository/kopia.repository.f ]; then
-                    echo "Kopia repository already exists"
-                    exit 0
-                fi
-                if find /repository -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
-                    echo "Refusing to initialize non-empty Kopia share" >&2
-                    exit 1
-                fi
-                kopia repository create filesystem \
-                    --create-only \
-                    --path=/repository \
-                    --config-file=/tmp/repository.config \
-                    --cache-directory=/tmp/cache \
-                    --override-hostname=volsync.volsync-system.svc.cluster.local \
-                    --override-username=volsync
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
       kopia:
         annotations:
           reloader.stakater.com/auto: "true"
@@ -147,10 +107,6 @@ spec:
       tmpfs:
         type: emptyDir
         advancedMounts:
-          bootstrap-repository:
-            app:
-              - path: /tmp
-                subPath: bootstrap
           kopia:
             app:
               - path: /config/cache

--- a/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
@@ -6,8 +6,6 @@ metadata:
   name: daily
 spec:
   enabled: true
-  # Temporarily prevent new maintenance during the NAS migration.
-  suspend: true
   activeDeadlineSeconds: 43200
   podSecurityContext:
     runAsUser: 0

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -5,8 +5,6 @@ kind: ReplicationSource
 metadata:
   name: ${APP}
 spec:
-  # Temporarily pause Synology-backed Kopia writes during the NAS migration.
-  paused: true
   sourcePVC: ${APP}
   trigger:
     schedule: "${VOLSYNC_KOPIA_SCHEDULE:-0 * * * *}"


### PR DESCRIPTION
## Summary
- remove the completed one-time Kopia bootstrap hook
- resume all 36 local Kopia ReplicationSources
- resume twice-daily Kopia maintenance

## Verified prerequisite
- fresh UNAS repository initialized successfully
- Kopia server is 1/1 ready with zero restarts
- repository ID `d7fc7d30fe7c2fea41a4fb5eed794e95d7a3e8d2406479c2c81e9696ae05634a`
- repository contains zero historical snapshots
- R2 ReplicationSources remained active

## Validation
- HelmRelease, ReplicationSource, and KopiaMaintenance schemas passed after substitution
- Kustomizations rendered successfully
- Kubernetes server-side dry-runs passed
