### PR TITLE
feat(home-assistant): restore UNAS music library

### DIFF
--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -186,7 +186,9 @@ spec:
           - path: /config/.cache/uv
 
       music:
-        type: emptyDir
+        type: nfs
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/music
         advancedMounts:
           homeassistant:
             app:


### PR DESCRIPTION
## Summary
- replace the migration-time emptyDir at `/music` with the UNAS NFS export
- mount `unas-direct.${SECRET_DOMAIN}:/var/nfs/shared/media/music` read-only in Home Assistant

## Data verification
- 1,008 retained files
- 20,761,102,370 bytes on both source and destination
- `rclone check`: 0 differences
- Synology `@eaDir` metadata omitted

## Validation
- HelmRelease app-template schema validation passed