### PR TITLE
feat(storage): initialize fresh Garage on UNAS

### DIFF
--- a/kubernetes/apps/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/app/helmrelease.yaml
@@ -80,13 +80,13 @@ spec:
             subPath: configuration.toml
       data:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/garage/data
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/garage/data
         globalMounts:
           - path: /data
       meta:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/garage/meta
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/garage/meta
         globalMounts:
           - path: /meta


### PR DESCRIPTION
## Summary
- move Garage data and LMDB metadata mounts from the retired Synology export to the fresh UNAS `garage` share
- use supported NFS paths through `unas-direct.${SECRET_DOMAIN}`
- intentionally do not import historical or partially staged Garage state

## Preparation
- confirmed the new Garage share was empty
- created fresh `data` and `meta` directories using the UNAS all-squash NFS identity

## Validation
- HelmRelease app-template schema validation passed
- Kustomize render passed