### PR TITLE
perf(cnpg): accelerate Garage backups

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
@@ -17,11 +17,11 @@ spec:
         name: cloudnative-pg-secret
         key: aws-secret-access-key
     wal:
-      compression: bzip2
+      compression: lz4
       maxParallel: 8
     data:
-      compression: bzip2
-      jobs: 1
+      compression: lz4
+      jobs: 2
       # Bound Garage's per-object metadata growth and tolerate NFS commit latency.
       additionalCommandArgs:
         - --max-archive-size=10GB

--- a/kubernetes/apps/media/immich/database/objectstore.yaml
+++ b/kubernetes/apps/media/immich/database/objectstore.yaml
@@ -17,11 +17,11 @@ spec:
         name: immich-db-superuser-secret
         key: aws-secret-access-key
     wal:
-      compression: bzip2
+      compression: lz4
       maxParallel: 8
     data:
-      compression: bzip2
-      jobs: 1
+      compression: lz4
+      jobs: 2
       # Bound Garage's per-object metadata growth and tolerate NFS commit latency.
       additionalCommandArgs:
         - --max-archive-size=10GB

--- a/kubernetes/apps/media/tracearr/database/objectstore.yaml
+++ b/kubernetes/apps/media/tracearr/database/objectstore.yaml
@@ -17,11 +17,11 @@ spec:
         name: tracearr-postgres-secret
         key: aws-secret-access-key
     wal:
-      compression: bzip2
+      compression: lz4
       maxParallel: 8
     data:
-      compression: bzip2
-      jobs: 1
+      compression: lz4
+      jobs: 2
       # Bound Garage's per-object metadata growth and tolerate NFS commit latency.
       additionalCommandArgs:
         - --max-archive-size=10GB


### PR DESCRIPTION
## Summary
- switch WAL and base-backup compression from CPU-heavy `bzip2` to `lz4`
- increase base-backup upload concurrency from one to two jobs
- apply consistently to PostgreSQL, Immich PostgreSQL, and Tracearr PostgreSQL

The currently running validation backup retains its original `bzip2 --jobs 1` invocation; these settings apply to future operations.

## Evidence
- current Barman sidecar saturates one CPU core at ~1000m
- UNAS RAID6 is still synchronizing, so concurrency is kept conservative at two jobs

## Validation
- all three ObjectStore resources passed CRD schema validation
- all three Kustomize overlays rendered successfully