### PR TITLE
feat(immich): restore UNAS photo library

### DIFF
--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -176,24 +176,24 @@ spec:
     persistence:
       library:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/photos/immich
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/photos/immich
         advancedMounts:
           server:
             app:
               - path: /data
       shared-photos:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/photos/shared
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/photos/shared
         advancedMounts:
           server:
             app:
               - path: /mnt/shared-photos
       archives:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/photos/archives
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/photos/archives
         advancedMounts:
           server:
             app:


### PR DESCRIPTION
## Summary
- point the Immich library at the UNAS `photos/immich` NFS path
- move shared photos and archives to their corresponding UNAS paths
- use the direct UNAS DNS endpoint consistently with other migrated services

## Migration evidence
- Photos copy completed at 2026-09-07 18:27:10 AEST
- rclone exit code: 0
- rclone errors: 0
- final transferred size: 1.265 TiB
- server-local paths are readable by the UNAS NFS identity

## Validation
- HelmRelease schema validation passed
- Immich Kustomize overlay rendered successfully