### PR TITLE
feat(downloads): restore SABnzbd on UNAS

### DIFF
--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -103,7 +103,8 @@ spec:
         existingClaim: sabnzbd
       downloads:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/downloads
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media
         globalMounts:
           - path: /downloads
+            subPath: downloads


### PR DESCRIPTION
## Summary
- move SABnzbd from the retired Synology download export to the UNAS `media` share
- expose the `downloads` subdirectory at the existing `/downloads` container path
- retain same-filesystem hardlink semantics for the later media-stack cutover

## Storage preparation
Created destination-only directories on Storage Pool 4:
- `media/downloads/complete/sab`
- `media/downloads/incomplete/sab`

The pre-migration SABnzbd queue was already verified empty.

## Validation
- HelmRelease schema validation passed
- Kustomize overlay rendered successfully