### PR TITLE
fix(observability): retain node saturation alert

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -31,6 +31,7 @@ spec:
     defaultRules:
       disabled:
         etcdMemberCommunicationSlow: true # custom rule in prometheusrules/etcd-rules.yaml (250ms threshold)
+        NodeSystemSaturation: true # custom rule in prometheusrules/node-rules.yaml
     alertmanager:
       ingress:
         enabled: false

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./etcd-rules.yaml
+  - ./node-rules.yaml
   - ./prometheusrule.yaml
   - ./wan-rules.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/node-rules.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/node-rules.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-rules
+  labels:
+    prometheus: k8s
+    role: alert-rules
+spec:
+  groups:
+    - name: node-exporter
+      rules:
+        - alert: NodeSystemSaturation
+          annotations:
+            description: |
+              System load per core at {{ $labels.instance }} has been above 2 for the last 15 minutes, is currently at {{ printf "%.2f" $value }}.
+              This might indicate this instance resources saturation and can cause it becoming unresponsive.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodesystemsaturation
+            summary: System saturated, load per core is very high.
+          expr: |-
+            node_load1{job="node-exporter"}
+            / count without (cpu, mode) (node_cpu_seconds_total{job="node-exporter", mode="idle"}) > 2
+          for: 15m
+          labels:
+            severity: warning


### PR DESCRIPTION
## Summary
- restore the `NodeSystemSaturation` rule as a generic Kubernetes node-exporter alert
- remove the retired `nas-direct` exclusion entirely
- retain the chart disable guard to prevent duplicate alerts if the upstream rule returns

This follows PR #3345, which removed all Synology Prometheus scrape targets. Live validation showed the current chart does not otherwise provide this alert.

## Validation
- HelmRelease and Kustomization schemas passed
- PrometheusRule passed Kubernetes server-side dry-run
- PromQL evaluated successfully through the live Prometheus API
- rendered overlay contains the generic rule and zero Synology references