### PR TITLE
feat(observability): collect Talos NVMe health

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/smart-rules.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrules/smart-rules.yaml
@@ -1,0 +1,96 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: smart-rules
+  labels:
+    prometheus: k8s
+    role: alert-rules
+spec:
+  groups:
+    - name: smartctl-exporter
+      rules:
+        - alert: SmartctlNoDevicesDiscovered
+          annotations:
+            description: smartctl_exporter on {{ $labels.instance }} discovered no storage devices.
+            summary: A SMART exporter cannot see any host devices.
+          expr: smartctl_devices{job=~"(talos|unas)-smart"} < 1
+          for: 5m
+          labels:
+            severity: critical
+        - alert: SmartctlDeviceUnhealthy
+          annotations:
+            description: SMART reports that {{ $labels.device }} on {{ $labels.instance }} is unhealthy.
+            summary: A storage device is reporting an unhealthy SMART status.
+          expr: smartctl_device_smart_status{job=~"(talos|unas)-smart"} != 1
+          for: 5m
+          labels:
+            severity: critical
+        - alert: SmartctlNVMeCriticalWarning
+          annotations:
+            description: NVMe device {{ $labels.device }} on {{ $labels.instance }} has critical-warning value {{ $value }}.
+            summary: An NVMe controller is reporting a critical warning.
+          expr: smartctl_device_critical_warning{job=~"(talos|unas)-smart"} > 0
+          for: 5m
+          labels:
+            severity: critical
+        - alert: SmartctlMediaErrorsDetected
+          annotations:
+            description: Device {{ $labels.device }} on {{ $labels.instance }} reports {{ $value }} unrecovered media errors.
+            summary: A storage device has recorded media errors.
+          expr: smartctl_device_media_errors{job=~"(talos|unas)-smart"} > 0
+          for: 5m
+          labels:
+            severity: critical
+        - alert: SmartctlATASectorErrors
+          annotations:
+            description: Device {{ $labels.device }} on {{ $labels.instance }} reports {{ $value }} {{ $labels.attribute_name }} sectors.
+            summary: An ATA device has reallocated, pending, or uncorrectable sectors.
+          expr: |-
+            smartctl_device_attribute{
+              job=~"(talos|unas)-smart",
+              attribute_name=~"Reallocated_Sector_Ct|Current_Pending_Sector|Offline_Uncorrectable",
+              attribute_value_type="raw"
+            } > 0
+          for: 5m
+          labels:
+            severity: warning
+        - alert: SmartctlNVMeSpareBelowThreshold
+          annotations:
+            description: NVMe device {{ $labels.device }} on {{ $labels.instance }} has less available spare than its vendor threshold.
+            summary: An NVMe device has exhausted its safe spare capacity.
+          expr: |-
+            smartctl_device_available_spare{job=~"(talos|unas)-smart"}
+            < on(job, instance, device)
+            smartctl_device_available_spare_threshold{job=~"(talos|unas)-smart"}
+          for: 5m
+          labels:
+            severity: critical
+        - alert: SmartctlNVMeWearHigh
+          annotations:
+            description: NVMe device {{ $labels.device }} on {{ $labels.instance }} has consumed {{ printf "%.0f" $value }}% of its rated endurance.
+            summary: NVMe endurance consumption is above 70%.
+          expr: |-
+            smartctl_device_percentage_used{job=~"(talos|unas)-smart"} >= 70
+            and on(job, instance, device)
+            smartctl_device_percentage_used{job=~"(talos|unas)-smart"} < 90
+          for: 30m
+          labels:
+            severity: warning
+        - alert: SmartctlNVMeWearCritical
+          annotations:
+            description: NVMe device {{ $labels.device }} on {{ $labels.instance }} has consumed {{ printf "%.0f" $value }}% of its rated endurance.
+            summary: NVMe endurance consumption is above 90%.
+          expr: smartctl_device_percentage_used{job=~"(talos|unas)-smart"} >= 90
+          for: 30m
+          labels:
+            severity: critical
+        - alert: SmartctlDeviceTemperatureHigh
+          annotations:
+            description: Device {{ $labels.device }} on {{ $labels.instance }} has remained at {{ printf "%.0f" $value }}°C for 10 minutes.
+            summary: A storage device is running hotter than 60°C.
+          expr: smartctl_device_temperature{job=~"(talos|unas)-smart", temperature_type="current"} > 60
+          for: 10m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/resources/unas-smart.json
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/resources/unas-smart.json
@@ -175,7 +175,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "smartctl_device_temperature{job=\"unas-smart\"}",
+          "expr": "smartctl_device_temperature{job=\"$job\",instance=\"$instance\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -267,7 +267,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "smartctl_device_smart_status{job=\"unas-smart\"}",
+          "expr": "smartctl_device_smart_status{job=\"$job\",instance=\"$instance\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -356,7 +356,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "smartctl_device_critical_warning{job=\"unas-smart\"}",
+          "expr": "smartctl_device_critical_warning{job=\"$job\",instance=\"$instance\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -426,7 +426,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "smartctl_device_power_on_seconds{job=\"unas-smart\"}",
+          "expr": "smartctl_device_power_on_seconds{job=\"$job\",instance=\"$instance\"}",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -513,7 +513,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "smartctl_device_media_errors{job=\"unas-smart\"}",
+          "expr": "smartctl_device_media_errors{job=\"$job\",instance=\"$instance\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -581,7 +581,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "smartctl_device_power_cycle_count{job=\"unas-smart\"}",
+          "expr": "smartctl_device_power_cycle_count{job=\"$job\",instance=\"$instance\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -662,7 +662,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "smartctl_device_error_log_count{job=\"unas-smart\"}",
+          "expr": "smartctl_device_error_log_count{job=\"$job\",instance=\"$instance\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -750,7 +750,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 18
       },
@@ -776,7 +776,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "smartctl_device_bytes_written{job=\"unas-smart\",device=~\"nvme.*\"}",
+          "expr": "smartctl_device_bytes_written{job=\"$job\",instance=\"$instance\",device=~\"nvme.*\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -825,8 +825,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 18
       },
       "id": 2,
@@ -854,7 +854,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "smartctl_device_available_spare{job=\"unas-smart\",device=~\"nvme.*\"}",
+          "expr": "smartctl_device_available_spare{job=\"$job\",instance=\"$instance\",device=~\"nvme.*\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -866,16 +866,142 @@
       ],
       "title": "Available Spare on NVME",
       "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 12,
+      "options": {
+        "minVizHeight": 200,
+        "minVizWidth": 200,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "smartctl_device_percentage_used{job=\"$job\",instance=\"$instance\",device=~\"nvme.*\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{device}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "NVMe Endurance Used",
+      "type": "gauge"
     }
   ],
   "refresh": "",
   "schemaVersion": 39,
   "tags": [
     "smart",
+    "talos",
     "unas"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(smartctl_device_smart_status, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(smartctl_device_smart_status, job)",
+          "refId": "PrometheusVariableQueryEditor-Job"
+        },
+        "refresh": 1,
+        "regex": "/(talos|unas)-smart/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(smartctl_device_smart_status{job=\"$job\"}, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(smartctl_device_smart_status{job=\"$job\"}, instance)",
+          "refId": "PrometheusVariableQueryEditor-Instance"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",
@@ -883,10 +1009,10 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "UNAS SMART Disk Data",
+  "title": "Storage SMART Disk Data",
   "uid": "unas-smart-disk-data",
   "version": 16,
   "weekStart": "",
   "gnetId": 20204,
-  "description": "Adapted for the UNAS Pro 8 from Grafana dashboard 20204 revision 1 (prometheus-community/smartctl_exporter)."
+  "description": "Adapted from Grafana dashboard 20204 revision 1 for UNAS and Talos smartctl_exporter jobs."
 }

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
@@ -13,6 +13,7 @@ spec:
         - unas-direct.${SECRET_DOMAIN}:9100
       labels:
         appliance: unas-pro-8
+        instance: UNAS-Pro-8
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/scrapeconfig_v1alpha1.json
 apiVersion: monitoring.coreos.com/v1alpha1
@@ -28,3 +29,4 @@ spec:
         - unas-direct.${SECRET_DOMAIN}:9633
       labels:
         appliance: unas-pro-8
+        instance: UNAS-Pro-8

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
   - ./kubetail/ks.yaml
   - ./loki/ks.yaml
   - ./silence-operator/ks.yaml
+  - ./smartctl-exporter/ks.yaml
   - ./unpoller/ks.yaml
   - ./vector/ks.yaml

--- a/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
@@ -1,0 +1,103 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app smartctl-exporter
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      smartctl-exporter:
+        type: daemonset
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: quay.io/prometheuscommunity/smartctl-exporter
+              tag: v0.14.0@sha256:cfe22c36d7d2fac48ebf619707305acb65eb0fb670656eb80f356e606d782bc1
+            args:
+              - --smartctl.interval=60s
+              - --smartctl.rescan=10m
+              - --web.listen-address=:9633
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 9633
+                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probe
+              startup:
+                enabled: false
+            securityContext:
+              # smartctl requires privileged NVMe admin ioctls; host access is limited to devices only.
+              privileged: true
+              readOnlyRootFilesystem: true
+              runAsUser: 0
+            resources:
+              requests:
+                cpu: 5m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+    persistence:
+      host-devices:
+        # Deliberately excludes host root, PID, IPC, and network namespaces.
+        type: hostPath
+        hostPath: /dev
+        hostPathType: Directory
+        globalMounts:
+          - path: /hostdev
+            readOnly: true
+    service:
+      app:
+        controller: smartctl-exporter
+        forceRename: *app
+        ports:
+          metrics:
+            port: *port
+    serviceMonitor:
+      app:
+        serviceName: *app
+        endpoints:
+          - port: metrics
+            path: /metrics
+            interval: 60s
+            scrapeTimeout: 30s
+            relabelings:
+              - action: replace
+                sourceLabels:
+                  - __meta_kubernetes_pod_node_name
+                targetLabel: instance
+              - action: replace
+                sourceLabels:
+                  - __meta_kubernetes_pod_node_name
+                targetLabel: kubernetes_node
+              - action: replace
+                replacement: talos-smart
+                targetLabel: job

--- a/kubernetes/apps/observability/smartctl-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/kustomization.yaml
@@ -3,8 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./etcd-rules.yaml
-  - ./node-rules.yaml
-  - ./prometheusrule.yaml
-  - ./smart-rules.yaml
-  - ./wan-rules.yaml
+  - ./helmrelease.yaml
+  - ./networkpolicy.yaml

--- a/kubernetes/apps/observability/smartctl-exporter/app/networkpolicy.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/networkpolicy.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.36.0-standalone-strict/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: smartctl-exporter
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: smartctl-exporter
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 9633
+          protocol: TCP
+  egress: []

--- a/kubernetes/apps/observability/smartctl-exporter/ks.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app smartctl-exporter
+  namespace: &namespace observability
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
+  path: ./kubernetes/apps/observability/smartctl-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary
- deploy one privileged smartctl_exporter pod per Talos node through app-template
- expose every NVMe, including non-Ceph devices, under the `talos-smart` Prometheus job
- restrict host access to `/dev`, allow ingress only from Prometheus, and deny exporter egress
- generalize the SMART dashboard across UNAS and Talos with job/instance selectors and NVMe endurance
- alert on missing devices, unhealthy SMART status, media/sector errors, spare exhaustion, wear, and temperature

## Security
- no host network, PID, IPC, or root filesystem mount
- no service-account token
- read-only container filesystem
- image pinned by tag and digest
- privileged access is limited to the exporter and required for NVMe admin ioctls

## Validation
- app-template HelmRelease schema passed
- rendered DaemonSet, Service, ServiceMonitor, and NetworkPolicy passed Kubernetes server dry-run
- Prometheus `promtool` accepted all 9 rules
- Kustomize and Flux strict substitution passed
- image digest resolves for Linux amd64
- independent review found no blockers
