### PR TITLE
fix(observability): preserve SMART job labels

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/resources/unas-smart.json
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/resources/unas-smart.json
@@ -961,7 +961,7 @@
           "type": "prometheus",
           "uid": "$${DS_PROMETHEUS}"
         },
-        "definition": "label_values(smartctl_device_smart_status, job)",
+        "definition": "label_values(smartctl_device_smart_status{job=~\"(talos|unas)-smart\"}, job)",
         "hide": 0,
         "includeAll": false,
         "label": "Job",
@@ -969,11 +969,11 @@
         "name": "job",
         "options": [],
         "query": {
-          "query": "label_values(smartctl_device_smart_status, job)",
+          "query": "label_values(smartctl_device_smart_status{job=~\"(talos|unas)-smart\"}, job)",
           "refId": "PrometheusVariableQueryEditor-Job"
         },
         "refresh": 1,
-        "regex": "/(talos|unas)-smart/",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"


### PR DESCRIPTION
## Summary
- remove the SMART dashboard Job variable's capture-group regex
- constrain the variable query directly to `talos-smart` and `unas-smart`
- preserve the complete Prometheus job labels used by every panel query

## Root cause
Grafana returns a regex capture group as the variable value. The previous `/(talos|unas)-smart/` regex therefore produced `talos` and `unas`, while the metrics are labelled `talos-smart` and `unas-smart`.

## Validation
- reproduced live as `Job=talos`, blank Instance, and no panel data
- JSON parsing passed
- Kustomize and Flux strict substitution passed
- live Prometheus query returns both complete job labels
- live instance queries return all five Talos nodes and `UNAS-Pro-8`
