### PR TITLE
feat(storage): complete and centralize UNAS NFS cutover

### DIFF
--- a/.taskfiles/VolSync/Taskfile.yaml
+++ b/.taskfiles/VolSync/Taskfile.yaml
@@ -122,7 +122,10 @@ tasks:
         ns: Namespace (default: default)
         timeout: Maximum wait in seconds (default: 300)
     cmds:
-      - envsubst '$app $ns $job $timeout' < {{.VOLSYNC_TEMPLATES_DIR}}/list.tmpl.yaml | kubectl --context admin@home-kubernetes create -f -
+      - |
+        export SECRET_NFS_DOMAIN
+        SECRET_NFS_DOMAIN="$(kubectl --context admin@home-kubernetes -n flux-system get secret cluster-secrets -o json | jq -er '.data.SECRET_NFS_DOMAIN | @base64d')"
+        envsubst '$app $ns $job $timeout $SECRET_NFS_DOMAIN' < {{.VOLSYNC_TEMPLATES_DIR}}/list.tmpl.yaml | kubectl --context admin@home-kubernetes create -f -
       - bash {{.VOLSYNC_SCRIPTS_DIR}}/wait-for-operation-job.sh {{.job}} {{.ns}} {{.timeout}}
       - kubectl --context admin@home-kubernetes -n {{.ns}} delete job {{.job}}
     env: *env

--- a/.taskfiles/VolSync/templates/list.tmpl.yaml
+++ b/.taskfiles/VolSync/templates/list.tmpl.yaml
@@ -45,5 +45,5 @@ spec:
       volumes:
         - name: repository
           nfs:
-            server: unas-direct.petrovic.network
+            server: ${SECRET_NFS_DOMAIN}
             path: /var/nfs/shared/kopia

--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -134,7 +134,7 @@ spec:
           - path: /dev/bus/usb
       media:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/frigate
         globalMounts:
           - path: /media

--- a/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/home-assistant/app/helmrelease.yaml
@@ -187,7 +187,7 @@ spec:
 
       music:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/music
         advancedMounts:
           homeassistant:

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -108,14 +108,14 @@ spec:
           - path: /config/log
       movies:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/movies
         globalMounts:
           - path: /movies
             readOnly: false
       tv:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/tv
         globalMounts:
           - path: /tv

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -108,15 +108,15 @@ spec:
           - path: /config/log
       movies:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/movies
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/movies
         globalMounts:
           - path: /movies
             readOnly: false
       tv:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/tv
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/tv
         globalMounts:
           - path: /tv
             readOnly: false

--- a/kubernetes/apps/media/grimmory/app/helmrelease.yaml
+++ b/kubernetes/apps/media/grimmory/app/helmrelease.yaml
@@ -136,7 +136,7 @@ spec:
               - path: /tmp
       books:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/books
         advancedMounts:
           grimmory:

--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -176,7 +176,7 @@ spec:
     persistence:
       library:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/photos/immich
         advancedMounts:
           server:
@@ -184,7 +184,7 @@ spec:
               - path: /data
       shared-photos:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/photos/shared
         advancedMounts:
           server:
@@ -192,7 +192,7 @@ spec:
               - path: /mnt/shared-photos
       archives:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/photos/archives
         advancedMounts:
           server:

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -172,8 +172,8 @@ spec:
         type: emptyDir
       movies:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/movies
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/movies
         advancedMounts:
           plex:
             app:
@@ -181,8 +181,8 @@ spec:
                 readOnly: true
       movies-kids:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/kids/movies
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/kids/movies
         advancedMounts:
           plex:
             app:
@@ -190,8 +190,8 @@ spec:
                 readOnly: true
       tv:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/tv
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/tv
         advancedMounts:
           plex:
             app:
@@ -199,8 +199,8 @@ spec:
                 readOnly: true
       tv-kids:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/kids/tv
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/kids/tv
         advancedMounts:
           plex:
             app:
@@ -208,8 +208,8 @@ spec:
                 readOnly: true
       music:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/music
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/music
         advancedMounts:
           plex:
             app:

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -172,7 +172,7 @@ spec:
         type: emptyDir
       movies:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/movies
         advancedMounts:
           plex:
@@ -181,7 +181,7 @@ spec:
                 readOnly: true
       movies-kids:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/kids/movies
         advancedMounts:
           plex:
@@ -190,7 +190,7 @@ spec:
                 readOnly: true
       tv:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/tv
         advancedMounts:
           plex:
@@ -199,7 +199,7 @@ spec:
                 readOnly: true
       tv-kids:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/kids/tv
         advancedMounts:
           plex:
@@ -208,7 +208,7 @@ spec:
                 readOnly: true
       music:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/music
         advancedMounts:
           plex:

--- a/kubernetes/apps/media/plexovic-gatus/app/config/config.yaml
+++ b/kubernetes/apps/media/plexovic-gatus/app/config/config.yaml
@@ -136,7 +136,7 @@ endpoints:
 
   - name: NAS Storage (NFS)
     group: storage
-    url: "tcp://${UNAS_NFS_DOMAIN}:111"
+    url: "tcp://${SECRET_NFS_DOMAIN}:111"
     interval: 1m
     ui:
       hide-hostname: true

--- a/kubernetes/apps/media/plexovic-gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plexovic-gatus/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
               GATUS_CONFIG_PATH: /config
               CUSTOM_WEB_PORT: &port 8080
               SECRET_PLEX_DOMAIN: ${SECRET_PLEX_DOMAIN}
-              UNAS_NFS_DOMAIN: unas-direct.${SECRET_DOMAIN}
+              SECRET_NFS_DOMAIN: ${SECRET_NFS_DOMAIN}
             envFrom:
               - secretRef:
                   name: plexovic-gatus-secret

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -136,7 +136,7 @@ spec:
         existingClaim: qbittorrent
       downloads:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media
         globalMounts:
           - path: /downloads

--- a/kubernetes/apps/media/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qui/app/helmrelease.yaml
@@ -88,7 +88,7 @@ spec:
         existingClaim: qui
       downloads:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media
         globalMounts:
           - path: /downloads

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -93,20 +93,20 @@ spec:
         existingClaim: radarr
       downloads:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/downloads
         globalMounts:
           - path: /downloads
       movies:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/movies
         globalMounts:
           - path: /movies
 
       movies-kids:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/kids/movies
         globalMounts:
           - path: /kids

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -103,7 +103,7 @@ spec:
         existingClaim: sabnzbd
       downloads:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media
         globalMounts:
           - path: /downloads

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -92,13 +92,13 @@ spec:
           - path: /var/log
       books:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/books
         globalMounts:
           - path: /books
       downloads:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/downloads
         globalMounts:
           - path: /downloads

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -86,19 +86,19 @@ spec:
         existingClaim: sonarr
       tv:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/tv
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/tv
         globalMounts:
           - path: /tv
       tv-kids:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/kids/tv
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/kids/tv
         globalMounts:
           - path: /kids
       downloads:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/downloads
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/downloads
         globalMounts:
           - path: /downloads

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -86,19 +86,19 @@ spec:
         existingClaim: sonarr
       tv:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/tv
         globalMounts:
           - path: /tv
       tv-kids:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/kids/tv
         globalMounts:
           - path: /kids
       downloads:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/downloads
         globalMounts:
           - path: /downloads

--- a/kubernetes/apps/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tdarr/app/helmrelease.yaml
@@ -181,7 +181,7 @@ spec:
               - path: /app/logs
       cache:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/downloads
         globalMounts:
           - path: /temp
@@ -192,28 +192,28 @@ spec:
           - path: /tmp
       movies:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/movies
         globalMounts:
           - path: /movies
             readOnly: false
       movies-kids:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/kids/movies
         globalMounts:
           - path: /movies-kids
             readOnly: false
       tv:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/tv
         globalMounts:
           - path: /tv
             readOnly: false
       tv-kids:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/kids/tv
         globalMounts:
           - path: /tv-kids

--- a/kubernetes/apps/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tdarr/app/helmrelease.yaml
@@ -181,8 +181,8 @@ spec:
               - path: /app/logs
       cache:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/downloads
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/downloads
         globalMounts:
           - path: /temp
             subPath: tdarr-cache
@@ -192,29 +192,29 @@ spec:
           - path: /tmp
       movies:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/movies
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/movies
         globalMounts:
           - path: /movies
             readOnly: false
       movies-kids:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/kids/movies
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/kids/movies
         globalMounts:
           - path: /movies-kids
             readOnly: false
       tv:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/tv
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/tv
         globalMounts:
           - path: /tv
             readOnly: false
       tv-kids:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/kids/tv
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/kids/tv
         globalMounts:
           - path: /tv-kids
             readOnly: false

--- a/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
     persistence:
       downloads:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/media/downloads
         globalMounts:
           - path: /downloads

--- a/kubernetes/apps/observability/unpoller/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/unpoller/app/externalsecret.yaml
@@ -16,8 +16,6 @@ spec:
       data:
         UP_UNIFI_DEFAULT_USER: "{{ .USERNAME }}"
         UP_UNIFI_DEFAULT_PASS: "{{ .PASSWORD }}"
-        UP_UNAS_DEVICE_0_USER: "{{ .UNAS_USERNAME }}"
-        UP_UNAS_DEVICE_0_PASS: "{{ .UNAS_PASSWORD }}"
   dataFrom:
     - extract:
         key: unifi-poller

--- a/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
@@ -41,10 +41,6 @@ spec:
               UP_UNIFI_DEFAULT_VERIFY_SSL: true
               UP_UNIFI_DEFAULT_SAVE_SITES: true
               UP_UNIFI_DEFAULT_SAVE_DPI: true
-              UP_UNAS_ENABLE: true
-              UP_UNAS_DEVICE_0_URL: https://${SECRET_UNAS_IP}
-              UP_UNAS_DEVICE_0_VERIFY_SSL: false
-              UP_UNAS_DEVICE_0_TIMEOUT: 60s
               UP_INFLUXDB_DISABLE: true
               UP_PROMETHEUS_DISABLE: false
               UP_PROMETHEUS_NAMESPACE: unpoller

--- a/kubernetes/apps/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/app/helmrelease.yaml
@@ -80,13 +80,13 @@ spec:
             subPath: configuration.toml
       data:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/garage/data
         globalMounts:
           - path: /data
       meta:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/garage/meta
         globalMounts:
           - path: /meta

--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -100,7 +100,7 @@ spec:
             subPath: repository.config
       repository:
         type: nfs
-        server: unas-direct.${SECRET_DOMAIN}
+        server: ${SECRET_NFS_DOMAIN}
         path: /var/nfs/shared/kopia
         globalMounts:
           - path: /repository

--- a/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
@@ -111,7 +111,7 @@ spec:
               value: Object.spec.template.spec.volumes{
                 name: "repository",
                 nfs: Object.spec.template.spec.volumes.nfs{
-                  server: "unas-direct.${SECRET_DOMAIN}",
+                  server: "${SECRET_NFS_DOMAIN}",
                   path: "/var/nfs/shared/kopia"
                 }
               }

--- a/kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml
@@ -44,7 +44,7 @@ spec:
               value: Object.spec.template.spec.volumes{
                 name: "repository",
                 nfs: Object.spec.template.spec.volumes.nfs{
-                  server: "unas-direct.${SECRET_DOMAIN}",
+                  server: "${SECRET_NFS_DOMAIN}",
                   path: "/var/nfs/shared/kopia"
                 }
               }

--- a/kubernetes/components/common/vars/cluster-secrets.sops.yaml
+++ b/kubernetes/components/common/vars/cluster-secrets.sops.yaml
@@ -10,11 +10,9 @@ stringData:
     SECRET_CLOUDFLARE_EMAIL: ENC[AES256_GCM,data:a97SDTDH/TW9f1Pno3BsNbLeRt0=,iv:pB4ogbGxdcbb8XpORwJQzVC1ijhDSAlZV30oBBQfvHA=,tag:zXL0TX0LzgYzgGH2GRq0yg==,type:str]
     SECRET_CLOUDFLARE_ACCOUNT_ID: ENC[AES256_GCM,data:RrGVXBSgzX7n1FEjLiIklTlxTHoiOUtSZnPEZoN6APQ=,iv:oZSHlzbXiE/fVVeVqlFc2IMej8JEc+ehC6EuQyM4qdQ=,tag:QnT4MfHow6C49TlzswDq5A==,type:str]
     SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:cmrIgug1qMj2jBlqA1iijgCbwSh48E7FzkIuelLQbPwJ/8NF,iv:otPMVM7yPvZmrLg3v0fCzDolCrLjIyFEZUy4uU2rndY=,tag:K8iD6oPSIy4a+BaLSdw38w==,type:str]
-    SECRET_NFS_DOMAIN: ENC[AES256_GCM,data:4Fj+nN6etQoRu36JKnXzffY8Vyd7j2oEihD8,iv:nKI+aLwTtPw97sVFwbV5ZuZQfULhufTzdFq+NzYapCA=,tag:qWaYnXBnmv0FY+uNS69vUg==,type:str]
-    SECRET_NFS_IP: ENC[AES256_GCM,data:clcHJFThL+T0,iv:64TQveQHmFeGKyjIkNISsjamaWz05vI9A1iO0pHQ1qo=,tag:+31u4rWDr9JfRMF3aunY6g==,type:str]
+    SECRET_NFS_DOMAIN: ENC[AES256_GCM,data:sFJpyGzQMqRoNzqTeK7WhJ9TyYCIi1HzpReVeQ==,iv:l+ky5TLDeVrKv7sd1c8cBa7yC2zJPuo2WeNIA4C5BTc=,tag:A2g1/YMLd0DoE9aR+fSgBA==,type:str]
     SECRET_SIGENERGY_IP: ENC[AES256_GCM,data:btA4jgOddu9zmw==,iv:N1LXn1TOEXiIqLQhVVtHSfdm0RNnwGqUlpN/mw69Qng=,tag:e9kelMvWEo4neA4ABpBQUA==,type:str]
     TZ: ENC[AES256_GCM,data:WE0+y+BvfM1feLWrqXXkGA==,iv:sAiBEf2XlqPNE5irq7/vKCbiwRqezIq0+8W08z3sLJw=,tag:CnnZTl+3Ry/x7Mhfne7tqg==,type:str]
-    SECRET_UNAS_IP: ENC[AES256_GCM,data:HUcVJ+HEL9rTSg==,iv:eHlU0nitIx7ub9Q99HlCprTs3tG+NCA0oyKGQqOvDrw=,tag:EUqumZELDLjslxQZSxYpdA==,type:str]
 # noinspection KubernetesUnknownKeys
 sops:
     age:
@@ -28,6 +26,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1pvlc4c05yg9g0pst6f6uvthh7942vt5tx79ycva92y8matj2ne5qvz4md5
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-09-07T01:52:33Z"
-    mac: ENC[AES256_GCM,data:sQLlQ6c5CxIGR8HSPYM/7ddhp5Phi7sZVlaM7g170pKlr+NkhXOezPaoKc/NmleoFiWInVz/rSMWCLUMJgyPq1ZiA3l7zml9FOfcpq53aXGvg/xAhsiaI1cuCiBlxz+72XzDa2fr8cRpd9l6T6S+owxDBdLZUwYQaDquu4MtHww=,iv:HnrrPTIRVL0g5o7GzIy9wtXxYf3VXR30nnsMNnPfDew=,tag:9Gyn3ltjDvxf3rbydidPaQ==,type:str]
+    lastmodified: "2026-09-08T04:14:58Z"
+    mac: ENC[AES256_GCM,data:XJWeoS0YoZQrNxdh2VJpQ5qgJ3LChJbBkhXw2BTmm9CRCBM9i56TbbxUPXXtIQYKHl4EDRsE++EmFMg5F+Fz05fkKQ5YZc5cjhCJrT0aMOmM4H80/jneuHJORw5CDuTSf0PFH9K3sRTK8yanTxgEmHrzNy2MVxgd1x/Vj5v7NTA=,iv:Ip/wvrJ9qZYmIPa8Ri/JiL3G4ystq6KaewbBt/nR97k=,tag:2i3sTkHHBCT2opWaaYqILA==,type:str]
     version: 3.11.0


### PR DESCRIPTION
## Summary
- move Plex, Bazarr, Sonarr, and Tdarr from Synology `/volume2/*` paths to permanent UNAS media exports
- update encrypted `SECRET_NFS_DOMAIN` to the canonical UNAS endpoint
- use `${SECRET_NFS_DOMAIN}` for every Flux-managed NFS consumer, including media, Photos, Garage, Kopia, Frigate, Home Assistant, and VolSync admission policies
- make the out-of-band VolSync snapshot-list task resolve the same value from the live `cluster-secrets` Secret instead of hardcoding a hostname
- remove Unpoller's unused UNAS collector and stop projecting its UNAS credentials into Kubernetes
- remove the now-unused `SECRET_UNAS_IP` and `SECRET_NFS_IP` cluster variables
- preserve existing application container paths and access modes

## Merge gate

> [!CAUTION]
> **Do not merge until both active TV copy workers finish with terminal success and zero errors.**

Changing the shared NFS endpoint and the final TV-dependent paths is deliberately kept in one gated rollout. Plex, Bazarr, Sonarr, and Tdarr enumerate, scan, or modify TV libraries that are still being populated; merging may restore these currently scaled-to-zero workloads.

## Validation
- app-template schema validation passed for all changed HelmReleases
- strict Flux builds and Kubernetes server-side dry-runs passed, including all TV-dependent workloads and Unpoller
- ExternalSecret schema validation passed
- SOPS integrity passed and decrypted assertions confirm `SECRET_NFS_DOMAIN=unas-direct.petrovic.network` with both IP variables absent
- rendered Unpoller resources contain no UNAS collector settings or credentials
- VolSync snapshot-list task parses, renders the centralized hostname, and passes Kubernetes server-side dry-run
- source scan found no remaining hardcoded NFS server or Synology `/volume*` path in workloads or generated Job templates
