### PR TITLE
feat(storage): cut over ready NFS workloads to UNAS

### DIFF
--- a/.taskfiles/VolSync/templates/list.tmpl.yaml
+++ b/.taskfiles/VolSync/templates/list.tmpl.yaml
@@ -45,5 +45,5 @@ spec:
       volumes:
         - name: repository
           nfs:
-            server: nas-direct.petrovic.network
-            path: /volume2/kopia
+            server: unas-direct.petrovic.network
+            path: /var/nfs/shared/kopia

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -9,7 +9,7 @@ Do **not** use this runbook if your goal is to preserve/adopt existing Ceph OSDs
 - **Infrastructure source of truth:** this Git repository on `main`.
 - **Secrets source of truth:** 1Password vault `k8s` plus the SOPS age key.
 - **Talos source of truth:** `talos/talconfig.yaml`, `talos/talenv.yaml`, `talos/talsecret.yaml`, and patches under `talos/patches/`.
-- **Primary app PVC restore:** VolSync Kopia restore from the NAS NFS repository at `/volume2/kopia`.
+- **Primary app PVC restore:** VolSync Kopia restore from the UNAS NFS repository at `/var/nfs/shared/kopia`.
 - **Secondary app backup:** Cloudflare R2 Restic backups. R2 is a fallback/manual restore path, not the default automatic bootstrap restore.
 - **Ceph stance:** always rebuild in this runbook. `wipeDevicesFromOtherClusters: true` is expected for this destructive path.
 
@@ -81,11 +81,11 @@ The bootstrap process also reads Talos secrets and initial Kubernetes secrets fr
    - `k8s-node-5` — `10.0.80.14`
    - Kubernetes API VIP — `10.0.80.99`
 
-3. Confirm the NAS is online and serving NFS for at least:
+3. Confirm the UNAS is online and serving NFS for at least:
 
-   - `/volume2/kopia` — primary VolSync restore repository
-   - any app-specific NFS paths used by media/home-automation workloads
-   - `/volume2/garage/*` if Garage object storage is being restored from NAS-backed state
+   - `/var/nfs/shared/kopia` — primary VolSync restore repository
+   - `/var/nfs/shared/media` and `/var/nfs/shared/photos` — application data
+   - `/var/nfs/shared/garage/{data,meta}` — Garage object storage state
 
 ## Preflight
 
@@ -177,12 +177,12 @@ This additionally checks:
 
 ### VolSync PVCs
 
-Persistent apps using `kubernetes/components/volsync` create PVCs with a `dataSourceRef` to a VolSync `ReplicationDestination`. On a destructive rebuild, those PVCs should restore automatically from the latest Kopia snapshot in the NAS repository.
+Persistent apps using `kubernetes/components/volsync` create PVCs with a `dataSourceRef` to a VolSync `ReplicationDestination`. On a destructive rebuild, those PVCs should restore automatically from the latest Kopia snapshot in the UNAS repository.
 
 Important details:
 
 - The default GitOps-created PVC restore uses **Kopia/NFS**. Use the manual R2 procedure if the Kopia repository is unavailable or missing the desired snapshot.
-- The NAS and `/volume2/kopia` must be available before VolSync mover jobs can restore.
+- The UNAS and `/var/nfs/shared/kopia` must be available before VolSync mover jobs can restore.
 - Cloudflare R2 Restic backups are retained as a secondary disaster copy. Manual R2 restore steps are documented in `kubernetes/components/volsync/README.md`.
 - After bootstrap, inspect VolSync objects and PVCs:
 

--- a/docs/agent/platform.md
+++ b/docs/agent/platform.md
@@ -29,7 +29,7 @@ scripts/                     # Helper scripts
 - Rook-Ceph `ceph-block` is the default StorageClass for most RWO volumes.
 - Rook-CephFS is used for RWX volumes.
 - OpenEBS `openebs-hostpath` provides local high-performance volumes, including VolSync R2 cache.
-- NFS on the Synology NAS is used for media storage and the Kopia repository at `/volume2/kopia`.
+- NFS on the UNAS Pro is used for media storage and the Kopia repository at `/var/nfs/shared/kopia`.
 - VolSync uses a dual-storage backup strategy:
   - Kopia primary backups to NFS.
   - Restic secondary backups to Cloudflare R2.

--- a/kubernetes/apps/automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/automation/frigate/app/helmrelease.yaml
@@ -133,8 +133,9 @@ spec:
         globalMounts:
           - path: /dev/bus/usb
       media:
-        type: emptyDir
-        sizeLimit: 100Gi
+        type: nfs
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/frigate
         globalMounts:
           - path: /media
 

--- a/kubernetes/apps/media/grimmory/app/helmrelease.yaml
+++ b/kubernetes/apps/media/grimmory/app/helmrelease.yaml
@@ -136,8 +136,8 @@ spec:
               - path: /tmp
       books:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/books
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/books
         advancedMounts:
           grimmory:
             app:

--- a/kubernetes/apps/media/plexovic-gatus/app/config/config.yaml
+++ b/kubernetes/apps/media/plexovic-gatus/app/config/config.yaml
@@ -136,7 +136,7 @@ endpoints:
 
   - name: NAS Storage (NFS)
     group: storage
-    url: "tcp://${SECRET_NFS_DOMAIN}:111"
+    url: "tcp://${UNAS_NFS_DOMAIN}:111"
     interval: 1m
     ui:
       hide-hostname: true

--- a/kubernetes/apps/media/plexovic-gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plexovic-gatus/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
               GATUS_CONFIG_PATH: /config
               CUSTOM_WEB_PORT: &port 8080
               SECRET_PLEX_DOMAIN: ${SECRET_PLEX_DOMAIN}
-              SECRET_NFS_DOMAIN: ${SECRET_NFS_DOMAIN}
+              UNAS_NFS_DOMAIN: unas-direct.${SECRET_DOMAIN}
             envFrom:
               - secretRef:
                   name: plexovic-gatus-secret

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -93,20 +93,20 @@ spec:
         existingClaim: radarr
       downloads:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/downloads
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/downloads
         globalMounts:
           - path: /downloads
       movies:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/movies
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/movies
         globalMounts:
           - path: /movies
 
       movies-kids:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/kids/movies
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/kids/movies
         globalMounts:
           - path: /kids

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -92,13 +92,13 @@ spec:
           - path: /var/log
       books:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/books
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/books
         globalMounts:
           - path: /books
       downloads:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/downloads
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/downloads
         globalMounts:
           - path: /downloads

--- a/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
     persistence:
       downloads:
         type: nfs
-        server: ${SECRET_NFS_DOMAIN}
-        path: /volume2/downloads
+        server: unas-direct.${SECRET_DOMAIN}
+        path: /var/nfs/shared/media/downloads
         globalMounts:
           - path: /downloads

--- a/kubernetes/components/volsync/README.md
+++ b/kubernetes/components/volsync/README.md
@@ -4,7 +4,7 @@ VolSync is a Kubernetes operator that provides automated backup and restore capa
 
 This VolSync setup uses a dual-storage strategy:
 
-- **Kopia (Primary)**: Frequent backups (hourly) stored in a Kopia filesystem repository on NFS (`/volume2/kopia`)
+- **Kopia (Primary)**: Frequent backups (hourly) stored in the UNAS Kopia filesystem repository at `/var/nfs/shared/kopia`
 - **Cloudflare R2 (Secondary)**: Daily backups stored in Cloudflare R2 via restic for disaster recovery; mover jobs do not mount or depend on the Kopia NFS repository
 
 ### Thundering Herd Prevention


### PR DESCRIPTION
## Summary
- move Grimmory, Radarr, Shelfmark, and Unpackerr from completed Synology-backed datasets to permanent UNAS media paths
- move Frigate recordings from the temporary `emptyDir` to the fresh permanent `media/frigate` path
- repoint the Plexovic Gatus NFS probe and VolSync snapshot-list helper to UNAS
- update bootstrap, platform, and VolSync documentation for the new Kopia export
- preserve all existing in-container paths and access modes

## Readiness
- Books, Movies, and Kids copy rows already completed successfully with zero migration errors
- Downloads and Frigate use fresh destination directories
- required `media/frigate` and `media/downloads/tdarr-cache` directories exist with `unifi-drive-nfs:unifi-drive` ownership and mode `2770`
- no extra targeted validation is required per the migration decision

Merging rolls the affected HelmReleases and may restore workloads currently scaled to zero. Downloader and Arr intake should remain controlled during the rollout.

## Validation
- app-template schema validation passed for all changed HelmReleases
- strict Flux builds passed
- Kubernetes server-side dry-runs passed
- rendered Frigate and Gatus targets resolve to `unas-direct.petrovic.network`
- rendered VolSync snapshot-list Job passed Kubernetes server-side dry-run
- repository scan found no remaining Synology NFS server or `/volume*` references in the changed workload manifests or generated Job template
