### PR TITLE
fix(observability): scope Ceph NIC errors to cluster nodes

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -41,6 +41,22 @@ spec:
         CephPoolGrowthWarning:
           expr: >-
             (max by (cluster, pool_id, instance) (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5)) * on(cluster,pool_id, instance) group_right() ceph_pool_metadata) >= 95
+        # Rook's upstream rule assumes Prometheus only scrapes cluster nodes.
+        # Scope it to the Talos node-exporter job so external node exporters such
+        # as UNAS cannot trigger a Ceph alert, and ignore transient microbursts.
+        CephNodeNetworkPacketErrors:
+          expr: |-
+            (
+              rate(node_network_receive_errs_total{device!="lo",job="node-exporter"}[1m]) +
+              rate(node_network_transmit_errs_total{device!="lo",job="node-exporter"}[1m])
+            ) / (
+              rate(node_network_receive_packets_total{device!="lo",job="node-exporter"}[1m]) +
+              rate(node_network_transmit_packets_total{device!="lo",job="node-exporter"}[1m])
+            ) >= 0.0001 or (
+              rate(node_network_receive_errs_total{device!="lo",job="node-exporter"}[1m]) +
+              rate(node_network_transmit_errs_total{device!="lo",job="node-exporter"}[1m])
+            ) >= 10
+          for: 5m
         # Ships with for:0, so it fires on any sub-second RX-drop microburst. On
         # k8s-node-5 a ~90s qBittorrent small-packet swarm concentrating on a
         # single i40e RX queue/CPU tripped it with zero Ceph impact (OSD latency


### PR DESCRIPTION
## Summary

- scope `CephNodeNetworkPacketErrors` to the Talos `node-exporter` scrape job
- exclude external node exporters such as `UNAS-Pro-8` from the Ceph-specific rule
- require errors to persist for five minutes before alerting

## Root cause

Rook's upstream rule selects `node_network_*` metrics globally. After adding the UNAS node exporter, real host-side RX FIFO bursts on `job="unas-node"` were therefore mislabeled as Ceph alerts and flapped because the rule had no `for` duration.

## Validation

- declared HelmRelease JSON schema: passed
- Rook Ceph cluster chart `v1.20.7` rendered successfully
- rendered alert contains `job="node-exporter"` on every metric selector and `for: 5m`
- corrected PromQL parsed successfully against Prometheus and excluded the UNAS series
