### PR TITLE
fix(media): set deterministic Arr probe hosts

### DIFF
--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -66,6 +66,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: prowlarr.media.svc.cluster.local
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -59,6 +59,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: radarr.media.svc.cluster.local
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -53,6 +53,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: sonarr.media.svc.cluster.local
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1


### PR DESCRIPTION
## Summary

- set deterministic HTTP `Host` headers on Sonarr, Radarr, and Prowlarr probes
- use each application's internal Kubernetes service FQDN
- apply the header to both liveness and readiness probes through the existing YAML anchors

This prepares the workloads for restrictive Arr Allowed Hosts settings without causing kubelet probes to be rejected based on dynamic Pod-IP Host headers.

## Validation

- all three app-template HelmRelease schemas passed
- media namespace Kustomize build passed
- app-template `5.1.0` rendered successfully for all three applications
- rendered Deployments contain the expected Host header on both liveness and readiness probes
