### PR TITLE
feat(media): deploy Maintainerr

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./grimmory/ks.yaml
   - ./immich/ks.yaml
   - ./jellyseerr/ks.yaml
+  - ./maintainerr/ks.yaml
   - ./plex/ks.yaml
   - ./plexovic-gatus/ks.yaml
   - ./profilarr/ks.yaml

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -1,0 +1,117 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app maintainerr
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 2
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    controllers:
+      maintainerr:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/maintainerr/maintainerr
+              tag: 3.27.0@sha256:64160eefe3a98a94fdbf8037b607ed7780a2fd95be233ef112c19e67a9bda638
+            env:
+              TZ: "${TZ}"
+              UI_HOSTNAME: 0.0.0.0
+              UI_PORT: &port 6246
+              LOG_LEVEL: info
+              TELEMETRY: "off"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health/live
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health/ready
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health/ready
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        hostnames:
+          - maintainerr.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
+
+    persistence:
+      data:
+        enabled: true
+        existingClaim: *app
+        globalMounts:
+          - path: /opt/data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/maintainerr/app/kustomization.yaml
+++ b/kubernetes/apps/media/maintainerr/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+components:
+  - ../../../../components/authelia-proxy

--- a/kubernetes/apps/media/maintainerr/ks.yaml
+++ b/kubernetes/apps/media/maintainerr/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app maintainerr
+  namespace: &namespace media
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/media/maintainerr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # no flux ks dependents
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_UID: "1000"
+      VOLSYNC_GID: "1000"
+      VOLSYNC_KOPIA_SCHEDULE: "54 * * * *"
+      VOLSYNC_R2_SCHEDULE: "25 5 * * *"


### PR DESCRIPTION
## Summary
- deploy Maintainerr 3.27.0 in the media namespace
- persist its SQLite configuration with VolSync-backed Ceph storage
- expose the internal UI through Envoy Gateway with Authelia protection
- disable upstream telemetry and run with a hardened security context

## Validation
- `mise exec uv@0.12.3 -- uvx check-jsonschema ...` for all changed schema-backed manifests
- `kustomize build kubernetes/apps/media/maintainerr/app`
- `kustomize build kubernetes/apps/media`
- `mise exec uv@0.12.3 -- uvx --from flux-local==8.1.0 flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose` (210 passed)
