### PR TITLE
fix(gdb): use portable unprotected scraper cache

### DIFF
--- a/kubernetes/apps/gdb/gdb/database/cluster.yaml
+++ b/kubernetes/apps/gdb/gdb/database/cluster.yaml
@@ -49,4 +49,4 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: gdb-garage
-        serverName: gdb-postgres-20260911
+        serverName: gdb-postgres

--- a/kubernetes/apps/gdb/gdb/ks.yaml
+++ b/kubernetes/apps/gdb/gdb/ks.yaml
@@ -96,27 +96,12 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  components:
-    - ../../../../components/volsync
   dependsOn:
     - name: gdb-migration
       namespace: gdb
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
-      namespace: volsync-system
   path: ./kubernetes/apps/gdb/gdb/scraper
-  postBuild:
-    substitute:
-      APP: *app
-      VOLSYNC_CAPACITY: 50Gi
-      VOLSYNC_ACCESSMODES: ReadWriteMany
-      VOLSYNC_STORAGECLASS: ceph-filesystem
-      VOLSYNC_SNAPSHOTCLASS: csi-ceph-filesystem
-      VOLSYNC_COPYMETHOD: Direct
-      VOLSYNC_R2_PAUSED: "true"
-      VOLSYNC_R2_SCHEDULE: "30 3 * * *"
-      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/gdb/gdb/scraper/kustomization.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/gdb/gdb/scraper/pvc.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gdb-scraper
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: ceph-filesystem

--- a/kubernetes/components/volsync/README.md
+++ b/kubernetes/components/volsync/README.md
@@ -91,9 +91,6 @@ R2 daily backups default to `30 2 * * *`. To customize:
 | `VOLSYNC_STORAGECLASS` | No | ceph-block | StorageClass for PVC |
 | `VOLSYNC_SNAPSHOTCLASS` | No | csi-ceph-blockpool | VolumeSnapshotClass for snapshots |
 | `VOLSYNC_R2_SCHEDULE` | No | 30 2 * * * | Cron schedule for R2 backups |
-| `VOLSYNC_R2_PAUSED` | No | false | Pause the R2 ReplicationSource |
-| `VOLSYNC_COPYMETHOD` | No | Snapshot | R2 copy method; use Direct for filesystems where snapshots are unsuitable |
-| `VOLSYNC_CACHE_CAPACITY` | No | 4Gi | Restic cache PVC size |
 
 ### Secret Management
 

--- a/kubernetes/components/volsync/r2.yaml
+++ b/kubernetes/components/volsync/r2.yaml
@@ -29,7 +29,6 @@ kind: ReplicationSource
 metadata:
   name: "${APP}-r2"
 spec:
-  paused: ${VOLSYNC_R2_PAUSED:-false}
   sourcePVC: "${APP}"
   trigger:
     schedule: "${VOLSYNC_R2_SCHEDULE:-30 2 * * *}"


### PR DESCRIPTION
## Summary
- remove the VolSync component and all cache-backup resources from GDB
- use a plain 50Gi RWX `ceph-filesystem` PVC so scraper jobs can move between nodes
- restore the requested Barman `serverName: gdb-postgres`
- revert the now-unused shared VolSync pause variable

## Safety
- the live scraper Flux stage is suspended while replacing the immutable component-backed PVC
- all scraper CronJobs remain suspended
- no scraper jobs have run against the cache

## Validation
- GDB namespace and stage Kustomize builds
- schema validation for the changed CNPG and Flux resources
- server-side dry-run admission for the portable PVC
- assertion that GDB contains no VolSync/R2/Restic resources or references
- `flux-local test --all-namespaces --enable-helm` (216 passed)
