### PR TITLE
chore(container): update gdb-scraper to 0.1.85

### DIFF
--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           scraper:
             image: &image
               repository: ghcr.io/adampetrovic/gdb-scraper
-              tag: 0.1.84@sha256:8c71e8b2611d5f64ec1f2329e19c687ff47bfba7a2a0ada1c15d0c7b57caff5d
+              tag: 0.1.85@sha256:df4e4b0f1aa3db5bc6386e502139dea75948260548b7754fd99ab36f0516a9a6
             env:
               DATABASE_URL: &databaseUrl
                 valueFrom:


### PR DESCRIPTION
## Summary
- update the pinned GDB scraper image from 0.1.84 to 0.1.85
- retain all suspended schedules and the portable unprotected cache PVC

## Validation
- app-template HelmRelease schema
- GDB scraper and namespace Kustomize builds
- `flux-local test --all-namespaces --enable-helm` (216 passed)
