### PR TITLE
fix(gdb): fail closed on incomplete fetches

### DIFF
--- a/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
+++ b/kubernetes/apps/gdb/gdb/scraper/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           scraper:
             image: &image
               repository: ghcr.io/adampetrovic/gdb-scraper
-              tag: 0.1.86@sha256:6d45c1718c8b63b349ab6013aad622543dcdcb4c9ea318e5d7526a9418fab2cc
+              tag: 0.1.87@sha256:fb48924882002c23820c96d507b58bbcdfa0f6977b87e74e21563694576d86d1
             env:
               DATABASE_URL: &databaseUrl
                 valueFrom:
@@ -57,6 +57,8 @@ spec:
               SOURCE: usag
               MODE: full
               CONCURRENCY: "50"
+              USAG_DOWNLOAD_TIMEOUT: "60"
+              USAG_REQUEST_ERROR_ABORT_COUNT: "100"
             probes: &disabledProbes
               liveness:
                 enabled: false


### PR DESCRIPTION
## Summary
- deploy gdb-scraper 0.1.87
- fail MSO fetch Jobs when any requested cache response is missing
- capture terminal Scrape.do/upstream status metadata for attribution
- reject incomplete manifests during replay
- raise USAG request timeout from 15s to 60s
- abort USAG after 100 terminal transport errors and reject incomplete run reports

## Safety
- all 12 CronJobs remain suspended
- fetch/replay secret boundaries are unchanged
- MSO remains concurrency 10
- no MMS fetch is active

## Validation
- source CI: 182 tests passed
- app-template schema validation
- Kustomize and server-side admission dry-run
- strict Flux substitution